### PR TITLE
Update devices-configuration.md

### DIFF
--- a/getting-started/devices-configuration.md
+++ b/getting-started/devices-configuration.md
@@ -4,7 +4,7 @@
 
 If you don't specify a device or OS version, then you will be allocated the default device image:
 
-**Android:** Pixel 7 (API level 33)
+**Android:** Pixel 7 (API level 34)
 
 **iOS:** iPhone 14 (iOS 17.2)
 

--- a/getting-started/devices-configuration.md
+++ b/getting-started/devices-configuration.md
@@ -4,7 +4,7 @@
 
 If you don't specify a device or OS version, then you will be allocated the default device image:
 
-**Android:** Pixel 6 (API level 33)
+**Android:** Pixel 7 (API level 33)
 
 **iOS:** iPhone 14 (iOS 17.2)
 


### PR DESCRIPTION
devices-configuration.md says the default device is the Pixel 6, API 33; it's actually the Pixel 7, API 34. (At least that's what all my tests say they're running on, when not passing in any custom device.)