### PR TITLE
Deprecate Maestro 1.39.1 and 2.4.0

### DIFF
--- a/configuration/maestro-versions.md
+++ b/configuration/maestro-versions.md
@@ -10,20 +10,18 @@ Please note that we periodically remove support for older versions so we always 
 
 We currently support the following versions of Maestro:
 
-* 1.39.1
 * 1.39.5
 * 1.41.0
 * 2.0.4
 * 2.0.9
 * 2.1.0
 * 2.2.0
-* 2.4.0
 * 2.5.0
 * 2.5.1
 * 2.6.0
 
 {% hint style="warning" %}
-Maestro 1.39.1 and 2.4.0 will be deprecated on the 29th May 2026. Please upgrade to a newer version.
+Maestro 1.39.1 and 2.4.0 were deprecated on 29th May 2026 and are no longer available. Please upgrade to a newer version.
 {% endhint %}
 
 ## Version Selection


### PR DESCRIPTION
## Summary
- Removes `1.39.1` and `2.4.0` from the available-versions list in `configuration/maestro-versions.md`.
- Flips the future-tense deprecation notice to past-tense so customers landing on this page after hitting an API 400 understand what changed today.

## Follow-up
The past-tense notice is temporary — should be removed entirely next month (~2026-06-29) to keep the doc clean of historical chatter.

## Context
Pairs with `moropo-com/dcd#<pending>`, `moropo-com/infra#<pending>`, `moropo-com/cli#<pending>`, `moropo-com/back-office#<pending>`.