### PR TITLE
docs: update CLI reference for v5 (login, live, MCP, binary install)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,7 +5,7 @@
 ## Getting Started
 
 * [Quick Start](getting-started/quickstart.md)
-* [API Keys](getting-started/api-keys.md)
+* [Authentication](getting-started/api-keys.md)
 * [Devices & OS Versions](getting-started/devices-configuration.md)
 * [Flows & Workspaces](getting-started/flows-and-workspaces.md)
 * [Concurrency & Parallel Runs](getting-started/concurrency-and-parallel-runs.md)
@@ -51,6 +51,9 @@
 * [Upload](cli/dcd-upload.md)
 * [Status](cli/dcd-status.md)
 * [List](cli/dcd-list.md)
+* [Login & Accounts](cli/dcd-login.md)
+* [Live Sessions](cli/dcd-live.md)
+* [MCP Server](cli/mcp-server.md)
 
 ## REST API
 

--- a/advanced/async-execution.md
+++ b/advanced/async-execution.md
@@ -5,7 +5,7 @@ By default, `dcd cloud` waits for all tests to complete before exiting. Async mo
 ## Basic Usage
 
 ```bash
-dcd cloud --apiKey <apiKey> <appFile> <flowFile> --async
+dcd cloud <appFile> <flowFile> --async
 ```
 
 When tests are submitted successfully, the command exits with code `0` regardless of test outcome. If submission itself fails, it exits with code `1`.
@@ -13,7 +13,7 @@ When tests are submitted successfully, the command exits with code `0` regardles
 Pair `--async` with `--name` to make it easy to look up results later:
 
 ```bash
-dcd cloud --apiKey <apiKey> <appFile> <flowFile> --async --name "build-$GIT_SHA"
+dcd cloud <appFile> <flowFile> --async --name "build-$GIT_SHA"
 ```
 
 ## Checking Results After an Async Run
@@ -21,7 +21,7 @@ dcd cloud --apiKey <apiKey> <appFile> <flowFile> --async --name "build-$GIT_SHA"
 Use the `dcd status` command to poll for results by upload ID:
 
 ```bash
-dcd status --apiKey <apiKey> <uploadId>
+dcd status --upload-id <uploadId>
 ```
 
 Or use the [dcd status](../cli/dcd-status.md) to query results programmatically via HTTP.

--- a/advanced/exit-codes.md
+++ b/advanced/exit-codes.md
@@ -13,10 +13,17 @@ Device Cloud uses standard exit codes to indicate the status of command executio
 ### General Errors
 
 ```bash
-1    # CLI failed due to bad workspace or dcd bug
+1    # CLI or infrastructure error (bad workspace, network failure, dcd bug)
 2    # Test run explicitly failed
 ```
 
+## JSON Output
+
+The two JSON flags behave differently around test failures:
+
+- **`--json`** — prints results as JSON to stdout but still signals the outcome through the exit code: `0` on success, `2` on test failure, `1` on CLI/infrastructure errors.
+- **`--json-file`** — writes results to a file and exits `0` even when the test run fails, so a failing test won't stop your pipeline. CLI/infrastructure errors still exit `1`.
+
 {% hint style="info" %}
-When using `--json` or `--json-file`, the CLI always exits 0. Test failures are communicated through the JSON output rather than the exit code.
+Use `--json-file` when you want to inspect the result yourself rather than have a non-zero exit code fail the build. Use `--json` when you still want the exit code to gate your pipeline.
 {% endhint %}

--- a/ci-cd/any-ci.md
+++ b/ci-cd/any-ci.md
@@ -2,10 +2,10 @@
 
 As DeviceCloud uses a simple CLI, you can run it in any CI service using a basic script in bash (or any lang).
 
-We recommend using npx so you don't need to install the npm package. For example:
+We recommend using npx so you don't need to install the npm package. In CI, authenticate with an [API key](../getting-started/api-keys.md) — set `DEVICE_CLOUD_API_KEY` as a secret, or pass `--api-key`. For example:
 
-```
-npx --yes @devicecloud.dev/dcd@latest cloud sample.zip ios-flow.yaml --quiet --apiKey ${{ secrets.DEV_DCD_API_KEY }}
+```bash
+npx --yes @devicecloud.dev/dcd@latest cloud sample.zip ios-flow.yaml --quiet --api-key ${{ secrets.DEV_DCD_API_KEY }}
 ```
 
 If you need advice - please ask in Discord, we'd be happy to provide pointers.

--- a/ci-cd/bitrise-steps.md
+++ b/ci-cd/bitrise-steps.md
@@ -15,6 +15,6 @@ DeviceCloud includes a BitRise step to allow automatic triggering of tests via y
 
 <figure><img src="../.gitbook/assets/Screenshot 2025-01-06 at 14.45.32.png" alt=""><figcaption></figcaption></figure>
 
-4. Populate the API key using a BitRise secret and set any variables. These should exactly match the DCD CLI.
+4. Populate the API key using a BitRise secret and set any variables. The step inputs mirror the [`dcd cloud`](../cli/dcd-cloud.md) flags — see that reference for the full list and accepted values.
 
 <figure><img src="../.gitbook/assets/Screenshot 2025-01-06 at 14.45.51.png" alt=""><figcaption></figcaption></figure>

--- a/ci-cd/eas-workflows.md
+++ b/ci-cd/eas-workflows.md
@@ -155,9 +155,13 @@ The build artifact itself is downloaded by `eas/download_build` and passed via `
 |----------|-------------|-----------|
 | `DCD_GH_SHA` | `${{ github.sha }}` | `gh_sha` metadata |
 | `DCD_GH_BRANCH` | `${{ github.ref_name }}` | `gh_branch` metadata |
+| `DCD_GH_RUN_ID` | `${{ github.run_id }}` | `gh_run_id` metadata |
+| `DCD_GH_PR_NUMBER` | `${{ github.event.pull_request.number }}` | `gh_pr_number` metadata |
+| `DCD_GH_PR_URL` | `${{ github.event.pull_request.html_url }}` | `gh_pr_url` metadata |
+| `DCD_GH_REPO` | `${{ github.repository }}` | `gh_repo` metadata |
 
 {% hint style="warning" %}
-`${{ github.event.pull_request.number }}` and `${{ github.repository }}` resolve to `null` on manual triggers and EAS rejects them as invalid env values. Only use them inside an `if:` guard that limits the job to PR events, or omit them. `github.sha` and `github.ref_name` coerce to empty strings safely.
+`${{ github.event.pull_request.number }}`, `${{ github.event.pull_request.html_url }}` and `${{ github.repository }}` resolve to `null` on manual triggers and EAS rejects them as invalid env values. Only set the PR and repo variables inside an `if:` guard that limits the job to PR events, or omit them. `github.sha`, `github.ref_name` and `github.run_id` coerce to empty strings safely.
 {% endhint %}
 
 ### Advanced
@@ -165,7 +169,8 @@ The build artifact itself is downloaded by `eas/download_build` and passed via `
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DEVICE_CLOUD_API_URL` | `https://api.devicecloud.dev` | Override the API URL (staging/dev environments). |
-| `DCD_USE_BETA` | `false` | Set to `true` to use the beta DCD CLI. |
+| `DCD_USE_BETA` | `false` | Set to the string `true` to use the beta DCD CLI (any other value is treated as `false`). |
+| `DCD_EAS_BUILD_URL` | — | Supply a build URL directly (mapped to `dcd cloud --app-url`) instead of downloading the artifact and passing `--app-file`. Useful when you host the binary yourself. |
 
 ---
 

--- a/ci-cd/eas-workflows.md
+++ b/ci-cd/eas-workflows.md
@@ -136,7 +136,7 @@ The wrapper turns these into either DCD flags or `--metadata` tags (so each run 
 
 | Variable | Source | Purpose |
 |----------|--------|---------|
-| `DEVICE_CLOUD_API_KEY` |`eas env:create --visibility secret` | DCD `--apiKey` (required). Auto-injected at runtime. |
+| `DEVICE_CLOUD_API_KEY` |`eas env:create --visibility secret` | DCD `--api-key` (required). Auto-injected at runtime. |
 
 ### Build context (recommended)
 
@@ -214,7 +214,7 @@ See the [Devices & OS Versions](../getting-started/devices-configuration.md) pag
 | `--env KEY=value` | Inject environment variables into your flows. Repeatable. |
 | `--name <name>` | Custom name for this test run. |
 | `--retry <n>` | Number of automatic retries on failure (max `2`). Retries are free. |
-| `--report <format>` | `junit`, `html`, `html-detailed`, `allure`. See [Report Formats](../test-reports/report-formats.md). |
+| `--report <format>` | `junit`, `html`, `html-detailed`, `allure`. See [Report Formats](../artifacts/report-formats.md). |
 
 ### Execution Options
 

--- a/ci-cd/github-actions.md
+++ b/ci-cd/github-actions.md
@@ -71,20 +71,7 @@ jobs:
 
 ### iOS with Expo
 
-If you build with EAS, you can pass the signed build URL directly using `app-url` instead of downloading the archive yourself. The URL is fetched and extracted automatically.
-
-```yaml
-- name: Build with EAS
-  run: eas build --platform ios --profile simulator --non-interactive --json > build.json
-
-- uses: devicecloud-dev/device-cloud-for-maestro@v2
-  with:
-    api-key: ${{ secrets.DCD_API_KEY }}
-    app-url: ${{ fromJson(steps.eas-build.outputs.result).artifacts.buildUrl }}
-    flows: .maestro/
-```
-
-> **Note:** Expo signed URLs expire after ~1 hour. Generate a fresh URL immediately before this step.
+If you build with EAS, download the build artifact in an earlier step and pass the resulting file to `app-file`. For a first-class Expo experience that wires this up for you, use the dedicated [EAS Workflows integration](eas-workflows.md) instead.
 
 ---
 
@@ -140,7 +127,7 @@ See the [Devices & OS Versions](../getting-started/devices-configuration.md) pag
 | `env` | No | — | Multiline list of environment variables (`KEY=value`) to inject into flows. |
 | `name` | No | Commit message | Custom name for this test run, visible in the console. |
 | `retry` | No | `0` | Number of retries on failure (max `2`). Retries are free — same as pressing retry in the UI. |
-| `report` | No | — | Report format. Options: `junit`, `html`, `html-detailed`, `allure`. See [Report Formats](../artifacts/report-formats.md). |
+| `report` | No | — | Report format. Options: `junit`, `html`. See [Report Formats](../artifacts/report-formats.md). |
 
 ### Android-Specific Options
 
@@ -157,15 +144,11 @@ See the [Devices & OS Versions](../getting-started/devices-configuration.md) pag
 
 ### GitHub / PR Context
 
-Attach Git and pull request metadata to a run. These values are displayed in the DeviceCloud console alongside the test results.
+The action automatically attaches Git and pull request metadata to each run, read from the GitHub Actions environment. These values are displayed in the DeviceCloud console alongside the results, so you can trace a run back to the commit or PR that triggered it — you don't need to pass branch, commit, or PR values yourself.
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `branch` | No | — | Git branch name for this run. |
-| `commit-sha` | No | — | Git commit SHA for this run. |
-| `repo-name` | No | — | Repository in `owner/repo` format (e.g. `acme/my-app`). |
-| `pr-number` | No | — | Pull request number. |
-| `pr-url` | No | — | Pull request URL. |
+| `include-github-context` | No | `true` | Automatically attach GitHub/PR context (branch, commit SHA, PR number, PR URL, run ID, repository) to the run as metadata. Set to `false` to opt out. |
 
 ### Execution Options
 
@@ -269,20 +252,16 @@ jobs:
 
 ## Common Patterns
 
-### Attach PR context to test runs
+### Opt out of automatic PR context
 
-Pass Git and PR metadata so each run is traceable back to the commit or PR that triggered it. The information is displayed in the DeviceCloud console.
+Git and PR metadata (branch, commit SHA, PR number/URL, repository, run ID) is attached automatically — see [GitHub / PR Context](#github--pr-context). To turn it off, set `include-github-context: false`:
 
 ```yaml
 - uses: devicecloud-dev/device-cloud-for-maestro@v2
   with:
     api-key: ${{ secrets.DCD_API_KEY }}
     app-file: app.apk
-    branch: ${{ github.head_ref || github.ref_name }}
-    commit-sha: ${{ github.sha }}
-    repo-name: ${{ github.repository }}
-    pr-number: ${{ github.event.pull_request.number }}
-    pr-url: ${{ github.event.pull_request.html_url }}
+    include-github-context: false
 ```
 
 ### Run async tests (non-blocking)

--- a/ci-cd/github-actions.md
+++ b/ci-cd/github-actions.md
@@ -140,7 +140,7 @@ See the [Devices & OS Versions](../getting-started/devices-configuration.md) pag
 | `env` | No | — | Multiline list of environment variables (`KEY=value`) to inject into flows. |
 | `name` | No | Commit message | Custom name for this test run, visible in the console. |
 | `retry` | No | `0` | Number of retries on failure (max `2`). Retries are free — same as pressing retry in the UI. |
-| `report` | No | — | Report format. Options: `junit`, `html`, `html-detailed`, `allure`. See [Report Formats](../test-results/report-formats.md). |
+| `report` | No | — | Report format. Options: `junit`, `html`, `html-detailed`, `allure`. See [Report Formats](../artifacts/report-formats.md). |
 
 ### Android-Specific Options
 

--- a/ci-cd/overview.md
+++ b/ci-cd/overview.md
@@ -5,7 +5,7 @@ DeviceCloud supports a wide range of CI/CD options. If you don't see your provid
 ### Integration Guides
 
 * [GitHub Actions](github-actions.md) - Full GitHub Actions integration with all options
-* [Bitrise](bitrise.md) - Bitrise integration
+* [Bitrise](bitrise-steps.md) - Bitrise integration
 * [Bitbucket Pipelines](bitbucket-pipelines.md) - Bitbucket Pipelines integration
 * [EAS Workflows](eas-workflows.md) - EAS integration
 * [Any CI](any-ci.md) - Generic integration using the CLI directly
@@ -14,8 +14,8 @@ DeviceCloud supports a wide range of CI/CD options. If you don't see your provid
 
 * [Async Execution](../advanced/async-execution.md) - Fire-and-forget tests without blocking your pipeline
 * [dcd status](../cli/dcd-status.md) - Poll for results after an async run
-* [Report Formats](../test-results/report-formats.md) - Generate JUnit/HTML reports for your CI system
-* [Artifacts & Downloads](../test-results/artifacts.md) - Access logs, screenshots, and videos
+* [Report Formats](../artifacts/report-formats.md) - Generate JUnit/HTML reports for your CI system
+* [Artifacts & Downloads](../artifacts/artifacts.md) - Access logs, screenshots, and videos
 
 ### Configuration
 

--- a/cli/dcd-artifacts.md
+++ b/cli/dcd-artifacts.md
@@ -77,4 +77,4 @@ UPLOAD_ID=$(jq -r .uploadId results.json)
 dcd artifacts --upload-id "$UPLOAD_ID" --download-artifacts ALL
 ```
 
-See [Async Execution](../advanced/async-execution.md) and [Report Formats](../test-results/report-formats.md) for more details.
+See [Async Execution](../advanced/async-execution.md) and [Report Formats](../artifacts/report-formats.md) for more details.

--- a/cli/dcd-cloud.md
+++ b/cli/dcd-cloud.md
@@ -21,7 +21,9 @@ The command blocks until all tests have completed, then exits with an appropriat
 
 | Flag | Description |
 |------|-------------|
-| `--api-key <key>` | Your DeviceCloud API key. Defaults to `DEVICE_CLOUD_API_KEY` env var |
+| `--api-key <key>` | Your DeviceCloud API key. Defaults to the `DEVICE_CLOUD_API_KEY` env var. Optional if you've run [`dcd login`](dcd-login.md) |
+
+See [Authentication](../getting-started/api-keys.md) for the full picture.
 
 ### App
 
@@ -29,8 +31,7 @@ The command blocks until all tests have completed, then exits with an appropriat
 |------|-------------|
 | `--app-binary-id <id>` | Reuse a previously uploaded binary instead of uploading again |
 | `--app-url <url>` | Signed URL to an Expo iOS build (`.tar.gz`). The archive is downloaded and extracted automatically. Expo signed URLs expire after ~1 hour. Mutually exclusive with `--app-file` |
-| `--additional-app-files <paths>` | Comma-separated list of additional app files to upload |
-| `--additional-app-binary-ids <ids>` | Comma-separated list of additional binary IDs to include |
+| `--app-file <path>` | Path to the app binary (alternative to the positional `<app-file>` argument) |
 | `--ignore-sha-check` | Force re-upload even if a binary with the same SHA already exists |
 
 ### Device
@@ -42,8 +43,8 @@ The command blocks until all tests have completed, then exits with an appropriat
 | `--ios-device <device>` | iOS device model to run on (see [Devices](../getting-started/devices-configuration.md)) |
 | `--ios-version <version>` | iOS version |
 | `--device-locale <locale>` | Device locale (see [Device Locale](../configuration/device-locale.md)) |
-| `--orientation <orientation>` | Device orientation (see [Orientation](../configuration/orientation.md)) |
-| `--google-play` | Use a Google Play-enabled device (see [Google Play APIs](../configuration/google-play-apis.md)) |
+| `--orientation <orientation>` | Device orientation, `0` (portrait) or `90` (landscape). Android only (see [Orientation](../configuration/orientation.md)) |
+| `--google-play` | Use a Google Play-enabled device. Android only (see [Google Play APIs](../configuration/google-play-apis.md)) |
 | `--runner-type <type>` | Runner type to use (see [Runner Types](../configuration/runner-type.md)) |
 
 ### Flows
@@ -52,7 +53,7 @@ The command blocks until all tests have completed, then exits with an appropriat
 |------|-------------|
 | `--flows <paths>` | Comma-separated list of flow files to run (alternative to positional arg) |
 | `--config <path>` | Path to a `config.yaml` workspace config file (see [Workspace Configuration](../configuration/workspace-config.md)) |
-| `--exclude-flows <paths>` | Comma-separated list of flow files to exclude |
+| `--exclude-flows <paths>` | Comma-separated list of flow files or sub-directories to exclude |
 | `--include-tags <tags>` | Only run flows with these tags (comma-separated) |
 | `--exclude-tags <tags>` | Skip flows with these tags (comma-separated) |
 
@@ -60,11 +61,11 @@ The command blocks until all tests have completed, then exits with an appropriat
 
 | Flag | Description |
 |------|-------------|
-| `--maestro-version <version>` | Maestro version to use (see [Maestro Versions](../configuration/maestro-versions.md)) |
+| `--maestro-version <version>` | Maestro version to use, or `latest` (see [Maestro Versions](../configuration/maestro-versions.md)) |
 | `--env <KEY=VALUE>` | Environment variables to pass to the test. Repeat for multiple values |
+| `--metadata <key=value>` | Arbitrary metadata to attach to the run (shown in the console). Repeat for multiple values |
 | `--name <name>` | Name for this upload (shown in the console) |
-| `--retry <n>` | Retry failed tests up to `n` times. Max `2` (see [Retry Strategies](../advanced/retry-strategies.md)) |
-| `--report <format>` | Generate a report. Options: `junit`, `html`, `html-detailed`, `allure` (see [Report Formats](../test-results/report-formats.md)) |
+| `--retry <n>` | Retry failed tests up to `n` times (free of charge). Max `2` (see [Retry Strategies](../advanced/retry-strategies.md)) |
 
 ### GitHub / PR Context
 
@@ -82,37 +83,44 @@ Attach Git and pull request metadata to a run. These values are displayed in the
 
 | Flag | Description |
 |------|-------------|
-| `--maestro-chrome-onboarding` | Run Chrome onboarding before tests (see [Chrome Onboarding](../advanced/chrome-onboarding.md)) |
-| `--android-no-snapshot` | Disable snapshot restore at test start |
+| `--maestro-chrome-onboarding` | Force Maestro-based Chrome onboarding. Slows tests but can fix browser-related crashes (see [Chrome Onboarding](../advanced/chrome-onboarding.md)) |
+| `--android-no-snapshot` | Force cold boot instead of snapshot boot. Automatically enabled for API 35+ |
+| `--show-crosshairs` | Display crosshairs for screen interactions during test execution |
 
 ### Performance
 
 | Flag | Description |
 |------|-------------|
-| `--disable-animations` | Disable device animations during test execution. On Android, disables system animation scales. On iOS, enables Reduce Motion. |
+| `--disable-animations` | Disable device animations during test execution. On Android, disables system animation scales. On iOS, enables Reduce Motion |
 
 ### Output & Execution
 
 | Flag | Description |
 |------|-------------|
-| `--async` | Submit tests and return immediately without waiting for results (see [Async Execution](../advanced/async-execution.md)) |
-| `--quiet` | Suppress per-test output; print only the final summary |
-| `--json` | Output results as JSON. Exits `0` even on test failure |
-| `--json-file <path>` | Write JSON results to a file |
-| `--download-artifacts <ALL\|FAILED>` | Download test artifacts after completion (see [Artifacts](../test-results/artifacts.md)) |
+| `--async` | Submit tests and return immediately (exit `0`) without waiting for results (see [Async Execution](../advanced/async-execution.md)) |
+| `--quiet`, `-q` | Suppress per-test progress; print only the final summary |
+| `--json` | Output results as JSON. Exits `0` on success, `2` on test failure, `1` on CLI/infrastructure errors |
+| `--json-file` | Write JSON results to a file (`<upload_id>_dcd.json` by default). Exits `0` even if the test run fails; infrastructure errors still exit `1` |
+| `--json-file-name <name>` | Custom name (or relative path) for the JSON file. Requires `--json-file` |
+| `--dry-run` | Simulate the run without uploading or triggering a test — useful for debugging workflow issues |
+| `--report <format>` | Generate and download a report. Options: `junit`, `html`, `html-detailed`, `allure` (see [Report Formats](../artifacts/report-formats.md)) |
+| `--junit-path <path>` | Output path for the JUnit report (requires `--report junit`) |
+| `--html-path <path>` | Output path for the HTML report (requires `--report html` or `html-detailed`) |
+| `--allure-path <path>` | Output path for the Allure report (requires `--report allure`) |
+| `--download-artifacts <ALL\|FAILED>` | Download test artifacts after completion (see [Artifacts](../artifacts/artifacts.md)) |
+| `--artifacts-path <path>` | Output path for the artifacts zip (default `./artifacts.zip`). Requires `--download-artifacts` |
 | `--debug` | Enable verbose debug logging |
-| `--use-beta` | Use the beta version of the DeviceCloud runner |
 
 ## Examples
 
 **Android:**
 ```bash
-dcd cloud app.apk flows/ --android-device "Pixel 8" --android-api-level 34
+dcd cloud app.apk flows/ --android-device pixel-7 --android-api-level 34
 ```
 
 **iOS:**
 ```bash
-dcd cloud app.zip flows/ --ios-device "iPhone 16" --ios-version 18
+dcd cloud app.zip flows/ --ios-device iphone-16 --ios-version 18
 ```
 
 **Filter by tag:**
@@ -127,5 +135,5 @@ dcd cloud flows/ --app-binary-id 67894274-b789-4c1e-80d4-da8998998999
 
 **Save results to JSON:**
 ```bash
-dcd cloud app.apk flows/ --json-file results.json
+dcd cloud app.apk flows/ --json-file --json-file-name results.json
 ```

--- a/cli/dcd-live.md
+++ b/cli/dcd-live.md
@@ -3,7 +3,7 @@
 Start an interactive cloud device session and drive it from your terminal — install a build, run individual Maestro commands or a whole flow, capture screenshots, and dump the view hierarchy. This is ideal for authoring and debugging flows against a real cloud device.
 
 {% hint style="warning" %}
-**Live is in beta** and is billed at **$0.03/min**. Access is enrollment-gated — if you're not enrolled, contact support to request access. `dcd live` requires a [`dcd login`](dcd-login.md) session.
+**Live is in beta** and is billed at **$0.03/min**. Access is limited and by request only. If you would like to try Live, please contact support to request access. `dcd live` requires a [`dcd login`](dcd-login.md) session.
 {% endhint %}
 
 ```bash

--- a/cli/dcd-live.md
+++ b/cli/dcd-live.md
@@ -1,0 +1,104 @@
+# dcd live
+
+Start an interactive cloud device session and drive it from your terminal — install a build, run individual Maestro commands or a whole flow, capture screenshots, and dump the view hierarchy. This is ideal for authoring and debugging flows against a real cloud device.
+
+{% hint style="warning" %}
+**Live is in beta** and is billed at **$0.03/min**. Access is enrollment-gated — if you're not enrolled, contact support to request access. `dcd live` requires a [`dcd login`](dcd-login.md) session.
+{% endhint %}
+
+```bash
+dcd live <subcommand> [flags]
+```
+
+A typical session: start a device, install a build, interact, then stop.
+
+```bash
+dcd live start --platform android --wait
+dcd live install --session <name> --app-binary-id <id> --wait
+dcd live run --session <name> path/to/flow.yaml
+dcd live stop --session <name>
+```
+
+Every subcommand (except `start`) takes a `--session <name>` flag identifying the session, and accepts `--api-key` / `--api-url`.
+
+## `dcd live start`
+
+Start a new live device session. Prints the session name and a console URL you can open to watch the device.
+
+| Flag | Description |
+|------|-------------|
+| `--platform <android\|ios>` | Device platform (default: `android`) |
+| `--app-binary-id <id>` | Binary upload ID to install on the device at start |
+| `--device-locale <locale>` | Device locale, e.g. `de_DE` |
+| `--android-device <device>` | Android only. Device profile (`pixel-6`, `pixel-6-pro`, `pixel-7`, `pixel-7-pro`) |
+| `--android-api-level <level>` | Android only. API level, e.g. `34` (must be passed together with `--android-device`) |
+| `--wait` | Block until the device is ready to accept commands |
+
+## `dcd live install`
+
+Install a binary on a running session's device.
+
+| Flag | Description |
+|------|-------------|
+| `--session <name>` | **Required.** Live session name |
+| `--app-binary-id <id>` | **Required.** Binary upload ID to install |
+| `--wait` | Block until the device is ready again after installing |
+
+## `dcd live exec`
+
+Execute one or more Maestro YAML commands against the session.
+
+| Flag | Description |
+|------|-------------|
+| `--session <name>` | **Required.** Live session name |
+| `--yaml <commands>` | Inline Maestro YAML commands, e.g. `--yaml "- launchApp"` |
+| `--file <path>` | Read the Maestro YAML to execute from a file (alternative to `--yaml`) |
+| `--wait` | Wait for the device to be ready before executing |
+
+Pass either `--yaml` or `--file`, not both.
+
+## `dcd live run`
+
+Run a whole Maestro flow file against the session. The flow's `appId:` header is handled automatically.
+
+| Flag | Description |
+|------|-------------|
+| `<flow-file>` | **Required.** Path to the Maestro flow file (positional argument) |
+| `--session <name>` | **Required.** Live session name |
+| `--timeout <seconds>` | Max seconds to wait for the flow to finish (default: `600`) |
+| `--wait` | Wait for the device to be ready before running |
+
+## `dcd live screenshot`
+
+Save the current device screen to an image file (PNG or JPEG, matching the device format).
+
+| Flag | Description |
+|------|-------------|
+| `--session <name>` | **Required.** Live session name |
+| `--output <path>`, `-o` | File path to write to (default: `live-screenshot.<ext>`) |
+
+## `dcd live hierarchy`
+
+Dump the current view hierarchy — the selectors (text, accessibility labels, resource IDs) you can tap and assert on.
+
+| Flag | Description |
+|------|-------------|
+| `--session <name>` | **Required.** Live session name |
+| `--json` | Output the raw hierarchy as JSON |
+| `--output <path>`, `-o` | Write the output to a file instead of stdout |
+
+## `dcd live status`
+
+Show a session's status — platform, readiness, current device phase, device model, locale, and time until auto-cancel.
+
+| Flag | Description |
+|------|-------------|
+| `--session <name>` | **Required.** Live session name |
+
+## `dcd live stop`
+
+Stop a live session.
+
+| Flag | Description |
+|------|-------------|
+| `--session <name>` | **Required.** Live session name |

--- a/cli/dcd-login.md
+++ b/cli/dcd-login.md
@@ -1,0 +1,70 @@
+# Login & Accounts
+
+These commands manage browser-based authentication and the organisation your runs are billed to. They're the recommended way to authenticate for local, interactive use. For CI and headless environments, use an [API key](../getting-started/api-keys.md) instead.
+
+## `dcd login`
+
+Authenticate with DeviceCloud via your browser. Run it once and the CLI stores your session, so subsequent commands don't need an API key.
+
+```bash
+dcd login
+```
+
+This opens your browser to complete sign-in (email OTP or Enterprise SSO). After you authorise the CLI, if you belong to more than one organisation you'll be prompted to pick the one to use. Your session is then saved locally (see [Where credentials are stored](#where-credentials-are-stored)).
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--no-browser` | Print the login URL instead of opening a browser. Useful over SSH or on machines without a browser — open the URL on any device to finish signing in |
+| `--api-url <url>` | API base URL to authenticate against (defaults to production) |
+| `--frontend-url <url>` | Override the frontend URL used to complete login |
+
+{% hint style="info" %}
+Login uses a PKCE browser flow with no local server, so it works over SSH and when you open the URL on a different device. A leaked login URL is inert — it can't be used to claim your session.
+{% endhint %}
+
+If you're already logged in, `dcd login` asks for confirmation before replacing the existing session.
+
+## `dcd logout`
+
+Clear the stored session and revoke it server-side (best effort).
+
+```bash
+dcd logout
+```
+
+This only affects the `dcd login` session — it does not touch the `DEVICE_CLOUD_API_KEY` environment variable or `--api-key` flag.
+
+## `dcd whoami`
+
+Show the user and organisation the CLI is currently acting as.
+
+```bash
+dcd whoami
+```
+
+Prints the logged-in user, the active organisation, and the environment. If you're not logged in, it points you to `dcd login` or `DEVICE_CLOUD_API_KEY`.
+
+## `dcd switch-org`
+
+Switch the active organisation for your logged-in session. Useful if you belong to more than one organisation.
+
+```bash
+# Interactive picker
+dcd switch-org
+
+# Switch directly by organisation name
+dcd switch-org "My Org"
+```
+
+Organisations are matched by name (case-insensitive). If a name is ambiguous, run `dcd switch-org` with no argument to pick interactively. Requires an active `dcd login` session — an exported `DEVICE_CLOUD_API_KEY` does not override the session here.
+
+## Where credentials are stored
+
+The session from `dcd login` is written to:
+
+- `$XDG_CONFIG_HOME/dcd/config.json`, or
+- `~/.dcd/config.json` if `XDG_CONFIG_HOME` is not set
+
+The file is created with `0600` permissions (owner read/write only) and holds your session tokens and the active organisation. Expiring sessions are refreshed automatically, so you rarely need to log in again.

--- a/cli/dcd-login.md
+++ b/cli/dcd-login.md
@@ -1,6 +1,6 @@
 # Login & Accounts
 
-These commands manage browser-based authentication and the organisation your runs are billed to. They're the recommended way to authenticate for local, interactive use. For CI and headless environments, use an [API key](../getting-started/api-keys.md) instead.
+These commands manage browser-based authentication and the team your runs are billed to. They're the recommended way to authenticate for local or interactive use. For CI and headless environments, you should use an [API key](../getting-started/api-keys.md) instead.
 
 ## `dcd login`
 
@@ -10,18 +10,17 @@ Authenticate with DeviceCloud via your browser. Run it once and the CLI stores y
 dcd login
 ```
 
-This opens your browser to complete sign-in (email OTP or Enterprise SSO). After you authorise the CLI, if you belong to more than one organisation you'll be prompted to pick the one to use. Your session is then saved locally (see [Where credentials are stored](#where-credentials-are-stored)).
+This opens your browser to complete sign-in (email OTP or Enterprise SSO). After you authorise the CLI, if you belong to more than one team you'll be prompted to pick the one to use. Your session is then saved locally (see [Where credentials are stored](#where-credentials-are-stored)).
 
 ### Flags
 
 | Flag | Description |
 |------|-------------|
-| `--no-browser` | Print the login URL instead of opening a browser. Useful over SSH or on machines without a browser — open the URL on any device to finish signing in |
-| `--api-url <url>` | API base URL to authenticate against (defaults to production) |
+| `--no-browser` | Print the login URL instead of opening a browser. Useful over SSH or on machines without a browser. |
 | `--frontend-url <url>` | Override the frontend URL used to complete login |
 
 {% hint style="info" %}
-Login uses a PKCE browser flow with no local server, so it works over SSH and when you open the URL on a different device. A leaked login URL is inert — it can't be used to claim your session.
+`dcd login` uses a PKCE browser flow with no local server, so it works over SSH and when you open the URL on a different device. A leaked login URL is inert and can't be used to claim your session.
 {% endhint %}
 
 If you're already logged in, `dcd login` asks for confirmation before replacing the existing session.
@@ -34,31 +33,31 @@ Clear the stored session and revoke it server-side (best effort).
 dcd logout
 ```
 
-This only affects the `dcd login` session — it does not touch the `DEVICE_CLOUD_API_KEY` environment variable or `--api-key` flag.
+This only affects the `dcd login` session and it does not touch the environment variables or the `--api-key` flag.
 
 ## `dcd whoami`
 
-Show the user and organisation the CLI is currently acting as.
+Show the user and team the CLI is currently acting as.
 
 ```bash
 dcd whoami
 ```
 
-Prints the logged-in user, the active organisation, and the environment. If you're not logged in, it points you to `dcd login` or `DEVICE_CLOUD_API_KEY`.
+Prints the logged-in user, the active team, and the environment. Does nothing if you're not logged in.
 
 ## `dcd switch-org`
 
-Switch the active organisation for your logged-in session. Useful if you belong to more than one organisation.
+Switch the active team for your logged-in session. Useful if you belong to more than one team.
 
 ```bash
 # Interactive picker
 dcd switch-org
 
-# Switch directly by organisation name
-dcd switch-org "My Org"
+# Switch directly by team name
+dcd switch-org "example@example.com's Team"
 ```
 
-Organisations are matched by name (case-insensitive). If a name is ambiguous, run `dcd switch-org` with no argument to pick interactively. Requires an active `dcd login` session — an exported `DEVICE_CLOUD_API_KEY` does not override the session here.
+Teams are matched by name (case-insensitive). Requires an active `dcd login` session and an exported `DEVICE_CLOUD_API_KEY` will not override the session.
 
 ## Where credentials are stored
 
@@ -67,4 +66,4 @@ The session from `dcd login` is written to:
 - `$XDG_CONFIG_HOME/dcd/config.json`, or
 - `~/.dcd/config.json` if `XDG_CONFIG_HOME` is not set
 
-The file is created with `0600` permissions (owner read/write only) and holds your session tokens and the active organisation. Expiring sessions are refreshed automatically, so you rarely need to log in again.
+The file is created with `0600` permissions (owner read/write only) and holds your session tokens and the active team. Expiring sessions are refreshed automatically, so you should rarely need to log in again.

--- a/cli/mcp-server.md
+++ b/cli/mcp-server.md
@@ -1,0 +1,53 @@
+# MCP Server
+
+The `@devicecloud.dev/dcd` package ships a second binary, `dcd-mcp` — a [Model Context Protocol](https://modelcontextprotocol.io) server that lets AI agents (Claude, Cursor, VS Code, and other MCP clients) drive DeviceCloud directly: list devices, submit cloud test runs, check status, and download artifacts.
+
+{% hint style="warning" %}
+The MCP server is a new, beta capability. The tool surface may change.
+{% endhint %}
+
+## Setup
+
+Add the server to your MCP client's configuration. It runs over stdio via `npx`, so there's nothing to install separately:
+
+```jsonc
+{
+  "mcpServers": {
+    "devicecloud": {
+      "command": "npx",
+      "args": ["-y", "@devicecloud.dev/dcd", "dcd-mcp"],
+      "env": { "DEVICE_CLOUD_API_KEY": "<your-api-key>" }
+    }
+  }
+}
+```
+
+## Authentication
+
+Auth is inherited from the CLI:
+
+- Set `DEVICE_CLOUD_API_KEY` in the server's `env` (as above), **or**
+- Run [`dcd login`](dcd-login.md) once and the server picks up the stored session.
+
+Point the server at a non-production environment with the `DCD_API_URL` environment variable.
+
+## Tools
+
+| Tool | What it does |
+|------|--------------|
+| `dcd_list_devices` | Discover available devices, OS versions, and Maestro versions |
+| `dcd_list_runs` | List recent test runs (filter by name/date, paginated) |
+| `dcd_get_status` | Get the status and per-test results of a run |
+| `dcd_download_artifacts` | Download a run's artifacts or report to disk |
+| `dcd_run_cloud_test` | Submit a flow to run on the cloud (**billable**) |
+
+By default `dcd_run_cloud_test` is asynchronous: it returns an `uploadId` immediately, which you poll with `dcd_get_status`. Pass `wait: true` (bounded by `waitTimeoutSeconds`) to block until the run completes, or `dryRun: true` to preview the flows without submitting.
+
+## Read-only mode
+
+`dcd_run_cloud_test` consumes test minutes, so it's annotated as a destructive/non-read-only tool — well-behaved clients can prompt before calling it. To hide it entirely (recommended for autonomous or untrusted agents), either:
+
+- pass `--read-only` in `args`, or
+- set `DCD_MCP_READONLY=1` in `env`.
+
+The remaining tools are all read-only.

--- a/cli/mcp-server.md
+++ b/cli/mcp-server.md
@@ -6,6 +6,10 @@ The `@devicecloud.dev/dcd` package ships a second binary, `dcd-mcp` — a [Model
 The MCP server is a new, beta capability. The tool surface may change.
 {% endhint %}
 
+{% hint style="warning" %}
+Please note that we accept no liability for anything your agent(s) may read or execute when using our MCP server. LLMs are a new technology and should be used with caution at your own risk.
+{% endhint %}
+
 ## Setup
 
 Add the server to your MCP client's configuration. It runs over stdio via `npx`, so there's nothing to install separately:
@@ -43,7 +47,7 @@ By default `dcd_run_cloud_test` is asynchronous: it returns an `uploadId` immedi
 
 ## Read-only mode
 
-`dcd_run_cloud_test` consumes test credits, so it's annotated as a destructive/non-read-only tool — well-behaved clients can prompt before calling it. To hide it entirely (recommended for autonomous or untrusted agents), either:
+`dcd_run_cloud_test` consumes test credits, so it's annotated as a destructive/non-read-only tool so well-behaved clients can (and should) prompt before calling it. To hide it entirely (recommended for autonomous or untrusted agents), either:
 
 - pass `--read-only` in `args`, or
 - set `DCD_MCP_READONLY=1` in `env`.

--- a/cli/mcp-server.md
+++ b/cli/mcp-server.md
@@ -27,9 +27,7 @@ Add the server to your MCP client's configuration. It runs over stdio via `npx`,
 Auth is inherited from the CLI:
 
 - Set `DEVICE_CLOUD_API_KEY` in the server's `env` (as above), **or**
-- Run [`dcd login`](dcd-login.md) once and the server picks up the stored session.
-
-Point the server at a non-production environment with the `DCD_API_URL` environment variable.
+- Run [`dcd login`](dcd-login.md) once and the server will pick up the stored session.
 
 ## Tools
 
@@ -45,7 +43,7 @@ By default `dcd_run_cloud_test` is asynchronous: it returns an `uploadId` immedi
 
 ## Read-only mode
 
-`dcd_run_cloud_test` consumes test minutes, so it's annotated as a destructive/non-read-only tool — well-behaved clients can prompt before calling it. To hide it entirely (recommended for autonomous or untrusted agents), either:
+`dcd_run_cloud_test` consumes test credits, so it's annotated as a destructive/non-read-only tool — well-behaved clients can prompt before calling it. To hide it entirely (recommended for autonomous or untrusted agents), either:
 
 - pass `--read-only` in `args`, or
 - set `DCD_MCP_READONLY=1` in `env`.

--- a/cli/overview.md
+++ b/cli/overview.md
@@ -1,22 +1,79 @@
 # CLI Reference
 
-The DCD CLI is the primary way to interact with DeviceCloud from your terminal or CI/CD pipeline. It is published as `@devicecloud.dev/dcd` on npm.
+The DCD CLI is the primary way to interact with DeviceCloud from your terminal or CI/CD pipeline. It is a drop-in replacement for `maestro cloud` — in most cases you can swap `maestro cloud` for `dcd cloud`.
+
+The CLI is published as `@devicecloud.dev/dcd` on npm and as a standalone binary. The same package also ships an [MCP server](mcp-server.md) so AI agents can drive DeviceCloud directly.
+
+{% hint style="info" %}
+**New in v5:** browser-based [`dcd login`](dcd-login.md) (no more passing a key on every command), a standalone binary installer with `dcd upgrade`, interactive [`dcd live`](dcd-live.md) device sessions, and an [MCP server](mcp-server.md). Existing API keys and `dcd cloud` usage continue to work unchanged.
+{% endhint %}
 
 ## Installation
+
+The recommended install is the standalone binary — it has no dependencies and doesn't require Node.
+
+{% tabs %}
+{% tab title="macOS / Linux" %}
+```bash
+curl -fsSL https://get.devicecloud.dev/install.sh | sh
+```
+{% endtab %}
+
+{% tab title="Windows" %}
+```powershell
+irm https://get.devicecloud.dev/install.ps1 | iex
+```
+{% endtab %}
+
+{% tab title="npm" %}
+Requires Node 22 or newer.
 
 ```bash
 npm install -g @devicecloud.dev/dcd
 ```
+{% endtab %}
+{% endtabs %}
+
+In CI, you can skip a separate install step and run the CLI directly with `npx`:
+
+```bash
+npx --yes @devicecloud.dev/dcd@latest cloud <app-file> <flows-dir>
+```
+
+## Upgrading
+
+If you installed the standalone binary, update it in place:
+
+```bash
+dcd upgrade
+```
+
+If you installed via npm, upgrade with npm instead:
+
+```bash
+npm install -g @devicecloud.dev/dcd@latest
+```
+
+{% hint style="info" %}
+`dcd upgrade` is only for binary installs. Automatic upgrade is not yet supported on Windows — re-run the PowerShell installer to update.
+{% endhint %}
 
 ## Authentication
 
-All commands require an API key. Set it as an environment variable to avoid passing it on every command:
+There are two ways to authenticate. See [Authentication](../getting-started/api-keys.md) for full detail.
+
+- **`dcd login`** (recommended for local use) — authenticate once in your browser. The CLI stores a session, so you don't have to pass a key on every command, and it unlocks live test updates.
+- **API key** (recommended for CI/headless) — set the `DEVICE_CLOUD_API_KEY` environment variable, or pass `--api-key <key>` on any command.
 
 ```bash
+# Local: log in once
+dcd login
+
+# CI / headless: provide an API key
 export DEVICE_CLOUD_API_KEY=your-api-key
 ```
 
-Or pass it explicitly with `--api-key <key>` on any command. You can find your API key in the console under **Settings → API Key**.
+When both are present, precedence is: `--api-key` flag → `DEVICE_CLOUD_API_KEY` env var → stored `dcd login` session.
 
 ## Commands
 
@@ -26,12 +83,18 @@ Or pass it explicitly with `--api-key <key>` on any command. You can find your A
 | [`dcd upload`](dcd-upload.md) | Upload an app binary and get a reusable binary ID |
 | [`dcd status`](dcd-status.md) | Check the status of a test upload |
 | [`dcd list`](dcd-list.md) | List recent uploads for your organisation |
-| `dcd help` | Display help for any command |
+| [`dcd artifacts`](dcd-artifacts.md) | Download artifacts or reports for a completed run |
+| [`dcd login`](dcd-login.md) | Authenticate via your browser |
+| [`dcd logout`](dcd-login.md#dcd-logout) | Clear the stored session |
+| [`dcd whoami`](dcd-login.md#dcd-whoami) | Show the logged-in user and active organisation |
+| [`dcd switch-org`](dcd-login.md#dcd-switch-org) | Switch the active organisation |
+| [`dcd live`](dcd-live.md) | Start and interact with a live device session (beta) |
+| `dcd upgrade` | Upgrade the standalone binary in place |
 
 ## Getting Help
 
 ```bash
-dcd help
-dcd help cloud
-dcd help status
+dcd --help
+dcd cloud --help
+dcd live --help
 ```

--- a/configuration/workspace-config.md
+++ b/configuration/workspace-config.md
@@ -67,7 +67,7 @@ If a flow name in `flowsOrder` doesn't match any discovered flow (e.g. after tag
 
 ### `notifications`
 
-Send email notifications when a run completes. See [Notifications](../test-results/notifications.md) for full context.
+Send email notifications when a run completes. See [Email Notifications](../notifications/email-notifications.md) for full context.
 
 ```yaml
 notifications:

--- a/getting-started/api-keys.md
+++ b/getting-started/api-keys.md
@@ -1,22 +1,70 @@
-# API Keys
+# Authentication
 
-Device Cloud uses API keys for authentication. This guide explains how to obtain, use, and manage your API keys.
+DeviceCloud supports two ways to authenticate the CLI: **browser login** (best for local, interactive use) and an **API key** (best for CI and headless environments). The REST API uses the API key.
 
-## Getting Your API Key
+## `dcd login` (recommended for local use)
 
-1. Log in to [devicecloud.dev](https://devicecloud.dev)
-2. Navigate to the console UI
-3. Find your API key in the settings/account section
+Run `dcd login` once and authenticate in your browser. The CLI stores the resulting session locally, so you don't need to pass a key on every command — and it unlocks live test updates and a smoother experience.
 
-## Using Your API Key
-
-### Command Line
 ```bash
-dcd cloud --apiKey your-api-key-here
+dcd login
 ```
 
-### Environment Variable
+This opens your browser, where you sign in (email OTP or Enterprise SSO) and authorise the CLI. If you belong to more than one organisation, you'll be prompted to pick one. The session is stored at:
+
+- `$XDG_CONFIG_HOME/dcd/config.json`, or
+- `~/.dcd/config.json` if `XDG_CONFIG_HOME` is not set
+
+The file is written with `0600` permissions (owner read/write only). Expiring sessions are refreshed automatically — you generally only log in again if you log out or switch machines.
+
+{% hint style="info" %}
+No browser on the box (e.g. over SSH)? Run `dcd login --no-browser` and the CLI prints a URL to open elsewhere.
+{% endhint %}
+
+See [Login & Accounts](../cli/dcd-login.md) for `logout`, `whoami`, and `switch-org`.
+
+## API key (recommended for CI / headless)
+
+In CI and other non-interactive environments, use an API key.
+
+### Getting your API key
+
+1. Log in to the [console](https://console.devicecloud.dev/settings)
+2. Open **Settings → API Key**
+3. Copy the key
+
+### Using your API key
+
+Set it as an environment variable so you don't have to pass it on every command:
+
 ```bash
 export DEVICE_CLOUD_API_KEY=your-api-key-here
-dcd cloud  # Key will be automatically used
+dcd cloud <appFile> <flowFile>
+```
+
+Or pass it explicitly with `--api-key` on any command:
+
+```bash
+dcd cloud --api-key your-api-key-here <appFile> <flowFile>
+```
+
+{% hint style="info" %}
+Store your API key as a secret in your CI provider (e.g. a GitHub Actions secret) — never commit it to your repository.
+{% endhint %}
+
+## Precedence
+
+When more than one credential is available, the CLI resolves authentication in this order:
+
+1. `--api-key` flag
+2. `DEVICE_CLOUD_API_KEY` environment variable
+3. Stored session from `dcd login`
+
+## REST API
+
+The [REST API](../api/overview.md) authenticates with the API key, passed in the `x-app-api-key` header:
+
+```bash
+curl https://api.devicecloud.dev/... \
+  -H "x-app-api-key: your-api-key-here"
 ```

--- a/getting-started/flows-and-workspaces.md
+++ b/getting-started/flows-and-workspaces.md
@@ -12,7 +12,7 @@ There are multiple ways to execute flows from the CLI:
 The most straightforward way to execute a single flow is to pass the flow file path directly to the CLI using a `<flowFile>`.
 
 ```
-dcd cloud --apiKey <apiKey> <appFile> <flowFile>
+dcd cloud <appFile> <flowFile>
 ```
 
 Where:
@@ -28,7 +28,7 @@ Where:
 ### 2. Executing flows by passing a directory
 
 ```
-dcd cloud --apiKey <apiKey> <appFile> <directoryPath>
+dcd cloud <appFile> <directoryPath>
 ```
 
 Where `<directoryPath>` is either:
@@ -41,7 +41,7 @@ The CLI will inspect all YAML files in the directory (but not sub-directories) a
 ### 3. Executing flows by passing a glob
 
 ```
-dcd cloud --apiKey <apiKey> <appFile> <glob>
+dcd cloud <appFile> <glob>
 ```
 
 Where `<glob>` is a path matching string such as `./**/*.yaml`
@@ -53,7 +53,7 @@ The CLI uses the [NPM glob](https://www.npmjs.com/package/glob) module. This pac
 For complex setups, a `config.yaml` file is recommended. Place it in the top-level directory you pass to the CLI and it will be detected automatically.
 
 ```
-dcd cloud --apiKey <apiKey> <appFile> <directoryPathIncludingConfigYaml>
+dcd cloud <appFile> <directoryPathIncludingConfigYaml>
 ```
 
 See [Workspace Configuration](../configuration/workspace-config.md) for more information.

--- a/getting-started/quickstart.md
+++ b/getting-started/quickstart.md
@@ -5,35 +5,63 @@ The dcd command line is intentionally designed to mimic the Maestro Cloud API. I
 ```bash
 # maestro cloud --apiKey <apiKey> <appFile> <flowFile>
 
-dcd cloud --apiKey <apiKey> <appFile> <flowFile>
+dcd cloud <appFile> <flowFile>
 ```
 
 ### 1. Install the CLI
 
-Install npm ([instructions here](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)), then run:
+The recommended install is the standalone binary — no Node required.
 
+{% tabs %}
+{% tab title="macOS / Linux" %}
+```bash
+curl -fsSL https://get.devicecloud.dev/install.sh | sh
 ```
+{% endtab %}
+
+{% tab title="Windows" %}
+```powershell
+irm https://get.devicecloud.dev/install.ps1 | iex
+```
+{% endtab %}
+
+{% tab title="npm" %}
+Install [Node 22+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), then run:
+
+```bash
 npm install -g @devicecloud.dev/dcd
 ```
+{% endtab %}
+{% endtabs %}
 
-### 2. Get your API key
+### 2. Authenticate
 
-You'll need an API key to trigger a flow run. Find it in the [console settings](https://console.devicecloud.dev/settings) page.
+Log in once in your browser — the CLI remembers your session, so you don't need to pass a key on every command:
 
-See [API Keys](api-keys.md) for more detail.
+```bash
+dcd login
+```
+
+Running in CI or a headless environment? Use an API key instead. Find it in the [console settings](https://console.devicecloud.dev/settings) page and set it as an environment variable:
+
+```bash
+export DEVICE_CLOUD_API_KEY=your-api-key
+```
+
+See [Authentication](api-keys.md) for more detail.
 
 ### 3. Run your first flow
 
 **iOS**
 
-```
-dcd cloud --apiKey <apiKey> <appFile>.app <flowFile>
+```bash
+dcd cloud <appFile>.app <flowFile>
 ```
 
 **Android**
 
-```
-dcd cloud --apiKey <apiKey> <appFile>.apk <flowFile>
+```bash
+dcd cloud <appFile>.apk <flowFile>
 ```
 
 That's it! Questions? Issues? Head to our Discord.
@@ -42,13 +70,21 @@ That's it! Questions? Issues? Head to our Discord.
 
 ### Upgrading the CLI
 
+If you installed the standalone binary:
+
+```bash
+dcd upgrade
 ```
+
+If you installed via npm:
+
+```bash
 npm install -g @devicecloud.dev/dcd@latest
 ```
 
 **Prerelease versions** (not recommended): Occasionally, prerelease versions are available under the `alpha`, `beta`, and `rc` tags, in increasing order of stability. See [available versions on NPM](https://www.npmjs.com/package/@devicecloud.dev/dcd?activeTab=versions).
 
-```
+```bash
 npm install -g @devicecloud.dev/dcd@alpha
 npm install -g @devicecloud.dev/dcd@beta
 npm install -g @devicecloud.dev/dcd@rc
@@ -64,7 +100,8 @@ Every flow has a 10-minute execution limit after which it will be automatically 
 
 ### Next steps
 
-- [Flows & Workspaces](flows.md) — organise and run multiple flows
+- [Flows & Workspaces](flows-and-workspaces.md) — organise and run multiple flows
 - [Devices & OS Versions](devices-configuration.md) — choose Android API level or iOS version
 - [App Management](../configuration/app-management.md) — upload and reuse binaries
 - [CI/CD Integration](../ci-cd/overview.md) — run tests in your pipeline
+```


### PR DESCRIPTION
The v5 CLI (@devicecloud.dev/dcd) is a citty-based rewrite that adds browser login, a standalone binary installer, live device sessions, and an MCP server. The docs still described the v4 OCLIF CLI.

- Installation: lead with the standalone binary installer (curl | sh / PowerShell) plus `dcd upgrade`; keep npm/npx (Node 22+) for CI.
- Authentication: present `dcd login` (browser session) first, with the API key documented as the CI/headless method; document precedence.
- cli/dcd-cloud.md: drop removed flags (--additional-app-*, --use-beta); add --metadata, --dry-run, --show-crosshairs, --json-file-name and the report/artifact path flags; mark Android-only flags; correct --json vs --json-file exit-code behaviour; fix device example IDs.
- Fix exit-codes page (--json exits 2 on failure; only --json-file forces 0).
- Fix broken links across CI/config pages (../test-results/, ../test-reports/, bitrise.md) and standardise --apiKey -> --api-key.
- New pages: cli/dcd-login.md, cli/dcd-live.md (beta), cli/mcp-server.md.
- SUMMARY: relabel "API Keys" -> "Authentication"; add the new CLI pages.