### PR TITLE
Add GitHub Checks docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -14,6 +14,7 @@
 
 * [Overview](ci-cd/overview.md)
 * [GitHub Actions](ci-cd/github-actions.md)
+* [GitHub Checks](ci-cd/github-checks.md)
 * [Bitrise Steps](ci-cd/bitrise-steps.md)
 * [EAS Workflows](ci-cd/eas-workflows.md)
 * [Bitbucket Pipelines](ci-cd/bitbucket-pipelines.md)

--- a/advanced/async-execution.md
+++ b/advanced/async-execution.md
@@ -63,4 +63,4 @@ jobs:
 - The console URL is available via the `DEVICE_CLOUD_CONSOLE_URL` action output so you can link to results from your CI summary.
 - Retries (`--retry`) and async mode work together — DeviceCloud handles retries in the background.
 - If you need the final pass/fail status in CI, use `dcd status` to poll or use the [dcd status](../cli/dcd-status.md) directly.
-- On GitHub, install the [DeviceCloud GitHub App](../ci-cd/github-checks.md) to have the async result posted back as a pass/fail **check** on your pull request — gate merges without polling for the result yourself.
+- With the [DeviceCloud GitHub App](../ci-cd/github-checks.md) installed, an async run reports its result back as a pass/fail check on the pull request, so you don't have to poll for it yourself.

--- a/advanced/async-execution.md
+++ b/advanced/async-execution.md
@@ -63,3 +63,4 @@ jobs:
 - The console URL is available via the `DEVICE_CLOUD_CONSOLE_URL` action output so you can link to results from your CI summary.
 - Retries (`--retry`) and async mode work together — DeviceCloud handles retries in the background.
 - If you need the final pass/fail status in CI, use `dcd status` to poll or use the [dcd status](../cli/dcd-status.md) directly.
+- On GitHub, install the [DeviceCloud GitHub App](../ci-cd/github-checks.md) to have the async result posted back as a pass/fail **check** on your pull request — gate merges without polling for the result yourself.

--- a/ci-cd/github-actions.md
+++ b/ci-cd/github-actions.md
@@ -276,7 +276,7 @@ Use `async: true` to start tests without blocking your pipeline. Then use [`dcd 
 ```
 
 {% hint style="info" %}
-With the [DeviceCloud GitHub App](github-checks.md) installed, an async run reports back as a pass/fail check on the pull request — handy for gating merges without a runner waiting around for results.
+With the [DeviceCloud GitHub App](github-checks.md) installed, an async run reports back as a pass/fail check on the pull request, so you can gate merges without keeping a runner alive to wait for results.
 {% endhint %}
 
 ### Filter tests by tag

--- a/ci-cd/github-actions.md
+++ b/ci-cd/github-actions.md
@@ -2,6 +2,8 @@
 
 The DeviceCloud GitHub Action is a drop-in replacement for the [Maestro Cloud Action](https://github.com/mobile-dev-inc/action-maestro-cloud). The inputs are identical where practical, so switching is straightforward.
 
+Additionally, you can setup our GitHub App to use GitHub Checks to manage Pull Requests and blocking. Read more (here)[github-checks.md].
+
 ## Quick Start
 
 ```yaml

--- a/ci-cd/github-actions.md
+++ b/ci-cd/github-actions.md
@@ -275,6 +275,10 @@ Use `async: true` to start tests without blocking your pipeline. Then use [`dcd 
     name: ${{ github.sha }}
 ```
 
+{% hint style="info" %}
+Install the [DeviceCloud GitHub App](github-checks.md) to get a pass/fail **check** posted directly on your pull requests when an async run finishes — so you can gate merges on your mobile tests without a runner waiting on results.
+{% endhint %}
+
 ### Filter tests by tag
 
 ```yaml

--- a/ci-cd/github-actions.md
+++ b/ci-cd/github-actions.md
@@ -276,7 +276,7 @@ Use `async: true` to start tests without blocking your pipeline. Then use [`dcd 
 ```
 
 {% hint style="info" %}
-Install the [DeviceCloud GitHub App](github-checks.md) to get a pass/fail **check** posted directly on your pull requests when an async run finishes — so you can gate merges on your mobile tests without a runner waiting on results.
+With the [DeviceCloud GitHub App](github-checks.md) installed, an async run reports back as a pass/fail check on the pull request — handy for gating merges without a runner waiting around for results.
 {% endhint %}
 
 ### Filter tests by tag

--- a/ci-cd/github-checks.md
+++ b/ci-cd/github-checks.md
@@ -63,7 +63,7 @@ At the top, the pass/fail count and total runtime. Below that, a table of every 
 Usually it's one of these:
 
 - **Nothing posts on the PR.** The App isn't installed on that repo, isn't connected to your team, or the run used a different team's API key. Check **Settings → Integrations**.
-- **The check is stuck in progress.** The run probably hasn't finished yet — find it in the console. The check only resolves once every flow reaches a final state.
+- **The check is stuck in progress.** The run probably hasn't finished yet. Look it up in the console; the check only resolves once every flow reaches a final state.
 - **"That GitHub account isn't linked."** Link your GitHub identity under **Settings → Account**, then connect.
 - **The check isn't in the branch-protection list.** It has to run once on the repo before GitHub will offer it. Open a pull request first.
 

--- a/ci-cd/github-checks.md
+++ b/ci-cd/github-checks.md
@@ -1,12 +1,14 @@
 # GitHub Checks
 
-Install the DeviceCloud GitHub App and every test run posts a pass/fail check on the pull request that started it. It works best with the Action's [`async`](github-actions.md#execution-options) mode: your workflow submits the run and exits after a few seconds, DeviceCloud runs the tests on its own devices, and the result lands on the PR when it's ready. Nothing sits waiting on a runner, so you're not burning CI minutes while the tests execute.
+Install the DeviceCloud GitHub App and every test run posts a pass/fail check on the pull request that started it. It works best with the Action's [`async`](github-actions.md#execution-options) mode where your workflow submits the run and exits after a few seconds, we run the tests on our own devices, and the result will land on the PR when it's ready. Nothing sits waiting on a runner, so you're not burning CI minutes while the tests execute.
 
-It's optional. Skip the App and the Action behaves exactly as it does today.
+{% hint style="info" %}
+You do not need to install our Checks app to use the GitHub Action, but you do need the GitHub Action to use Checks.
+{% endhint %}
 
 ## How it works
 
-The Action submits your tests and, with `async: true`, returns straight away. DeviceCloud posts an in-progress check against the PR's commit and updates it to passed or failed once every flow has finished. The check links back to the full run in the console, and because it's an ordinary GitHub check you can require it in branch protection to keep failing builds out of your main branch.
+The Action submits your tests and either polls for results or if you set `async: true`, returns straight away. DeviceCloud posts an in-progress check against the PR's commit and updates it to passed or failed once every flow has finished. The check links back to the full run in the console, and because it's an ordinary GitHub check you can require it in branch protection to keep failing builds out of your main branch.
 
 ## Connect the App
 
@@ -15,12 +17,12 @@ Open **Settings → Integrations** in the [console](https://console.devicecloud.
 A few things worth knowing:
 
 - Only owners and admins can connect GitHub for a team.
-- Your GitHub account needs to be linked to DeviceCloud first, under **Settings → Account**. If it isn't, the connect flow will say so.
-- If you're an admin on more than one team, you'll be asked which one to connect.
+- Your GitHub account needs to be linked to DeviceCloud first, under **Settings → Account**.
+- If you're an admin on more than one team, you may be asked which one to connect if we can't figure it out automatically using account context.
 
 ## Run your tests
 
-Run the [Action](github-actions.md) on your pull requests with `async: true`. It attaches the branch, commit, and PR number for you, which is how DeviceCloud knows where to post the check, so leave [`include-github-context`](github-actions.md#github--pr-context) on (it already is by default).
+Run the [Action](github-actions.md) on your pull requests with `async: true`. It attaches the branch, commit, and PR number for you, which is how DeviceCloud knows where to post the check, so ensure you do not disable [`include-github-context`](github-actions.md#github--pr-context) (it's enabled by default).
 
 ```yaml
 on:
@@ -40,23 +42,21 @@ jobs:
           async: true
 ```
 
-The one thing to get right: the `api-key` you pass has to belong to the same team the App is connected to. If it doesn't, DeviceCloud can't match the run to your installation and nothing gets posted.
-
 ## Require it before merging
 
 To make the check a merge gate, add it to a branch protection rule: your repo's **Settings → Branches → Require status checks to pass**, then pick **DeviceCloud**. GitHub only lists a check here after it's run at least once, so open a pull request before you set up the rule.
 
 ## Re-running failures
 
-A failed check has a **Re-run failed tests** button. It re-runs only the flows that failed (free, the same as hitting retry in the console) and moves the check back to in-progress until they finish. GitHub's own re-run button on the check does the same thing.
+A failed check has a **Re-run failed tests** button. It re-runs only the flows that failed and is completely free, just like retries from the CI. It'll move the check back to in-progress until they finish.
 
 ## What the check shows
 
-At the top, the pass/fail count and total runtime. Below that, a table of every flow with its result, the reason for anything that failed, and a link into the console for the logs, video, and screenshots.
+The pass/fail count and total runtime. Below that, a table of every flow with its result, the reason for anything that failed, and a link into the console for the logs, video, and screenshots.
 
 ## Managing the connection
 
-**Settings → Integrations** shows the connected account and the repositories the App can reach. Owners and admins can disconnect from there, which removes the App from GitHub and stops the checks. If you reconnect later, DeviceCloud picks up your existing installation instead of making you install again.
+**Settings → Integrations** shows the connected account and the repositories the App can reach. Owners and admins can disconnect from there, which removes the App from GitHub and stops the checks. If you reconnect later, DeviceCloud picks up your existing installation instead of making you install again. You can also remove the App from your GitHub settings.
 
 ## When a check doesn't show up
 

--- a/ci-cd/github-checks.md
+++ b/ci-cd/github-checks.md
@@ -1,0 +1,102 @@
+# GitHub Checks
+
+The DeviceCloud GitHub App posts a pass/fail **check** on your pull requests when a test run finishes. Paired with the GitHub Action's [`async`](github-actions.md#execution-options) mode, this lets you run your mobile E2E suite **fully asynchronously** — your CI job submits the run and exits in seconds, while DeviceCloud runs the tests and reports the result straight back on the pull request.
+
+The payoff: your PRs get a real pass/fail gate from your mobile tests **without a CI runner sitting idle** waiting for them to finish — so you spend a fraction of the CI minutes.
+
+{% hint style="info" %}
+GitHub Checks are optional and complement the [GitHub Action](github-actions.md). If you don't install the App, the Action behaves exactly as before — blocking or `async`, your choice.
+{% endhint %}
+
+## How it works
+
+1. Your GitHub Action submits a run with `async: true` and exits immediately — the CI job is done in seconds.
+2. DeviceCloud posts an **in-progress** check on the pull request's commit.
+3. When the run completes, the check resolves to **success** or **failure**, with a summary of every flow, the failures, and a link to the full results in the console.
+4. Because it's a native GitHub check, you can **require it in branch protection** to gate merges.
+
+## Setup
+
+### 1. Install & connect the DeviceCloud GitHub App
+
+In the [console](https://console.devicecloud.dev/settings), open **Settings → Integrations → Connect GitHub**. You'll be sent to GitHub to install the **DeviceCloud** App and choose which repositories it can access. When you come back, the App is connected to your current team.
+
+{% hint style="info" %}
+Only team **owners and admins** can connect GitHub. If your GitHub account isn't linked to DeviceCloud yet, link it under **Settings → Account** first, then connect.
+{% endhint %}
+
+If you administer more than one DeviceCloud team, you'll be asked which team to attach the installation to.
+
+### 2. Run the Action with `async`
+
+Run the [GitHub Action](github-actions.md) on your pull requests with `async: true`. The PR context (branch, commit SHA, PR number) is attached automatically, so DeviceCloud knows which pull request to post the check on.
+
+```yaml
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  mobile-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # build your app, or download a prebuilt artifact from an earlier job...
+      - uses: devicecloud-dev/device-cloud-for-maestro@v2
+        with:
+          api-key: ${{ secrets.DCD_API_KEY }}
+          app-file: app/build/outputs/apk/release/app-release.apk
+          async: true
+```
+
+The job submits and exits in seconds, and the DeviceCloud check appears on the PR — resolving to pass/fail when the run finishes.
+
+{% hint style="warning" %}
+The check only posts when DeviceCloud can tie the run to a repository the App is installed on. Keep [`include-github-context`](github-actions.md#github--pr-context) at its default (`true`) so the PR and commit metadata are attached, and make sure the Action's `api-key` belongs to the same team the App is connected to.
+{% endhint %}
+
+### 3. (Optional) Require the check to gate merges
+
+To block merges on the result, add the check to your branch protection rule:
+
+**GitHub → your repository → Settings → Branches → Add/Edit branch protection rule → Require status checks to pass before merging** — then select the **DeviceCloud** check.
+
+{% hint style="info" %}
+A check only appears in the branch-protection picker after it has run at least once on that repository. Open one pull request first, then add it to the rule.
+{% endhint %}
+
+## Re-running failed tests
+
+When a check fails it includes a **Re-run failed tests** button. Pressing it re-runs only the failed flows on DeviceCloud — free, exactly like the retry button in the console — and re-opens the check, which resolves again when the reruns finish. GitHub's built-in **Re-run** on the check does the same thing.
+
+## The check summary
+
+A resolved check shows:
+
+- A headline with the pass/fail count and total duration.
+- A table of every flow and its result.
+- A **Failures** section listing the reason for each failed flow.
+- A link to the full run — logs, video, and screenshots — in the DeviceCloud console.
+
+## Managing the connection
+
+From **Settings → Integrations** you can see the connected GitHub account and the repositories the App can access, and **Disconnect** at any time (owner/admin only). Disconnecting uninstalls the App from GitHub and stops posting checks; you can reconnect whenever you like — the App recovers your existing installation without a fresh install.
+
+## Requirements
+
+- The repository is hosted on GitHub and has the **DeviceCloud** App installed.
+- The App is connected to the DeviceCloud team that owns the `api-key` used by the Action.
+- The run carries PR/commit context — on by default via the Action's [`include-github-context`](github-actions.md#github--pr-context).
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| No check appears on the PR | Confirm the DeviceCloud App is **installed on the repo** and **connected to your team** (Settings → Integrations), and that the run used that team's API key. |
+| Check stays "in progress" | The run is likely still executing — check the console. The check resolves once every flow reaches a terminal state. |
+| "That GitHub account isn't linked" when connecting | Link your GitHub identity under **Settings → Account**, then connect. |
+| The check isn't listed in branch protection | It only appears after it has run once on that repository. Open a pull request first. |
+
+---
+
+**Related:** [GitHub Actions](github-actions.md) · [Async Execution](../advanced/async-execution.md)

--- a/ci-cd/github-checks.md
+++ b/ci-cd/github-checks.md
@@ -1,35 +1,26 @@
 # GitHub Checks
 
-The DeviceCloud GitHub App posts a pass/fail **check** on your pull requests when a test run finishes. Paired with the GitHub Action's [`async`](github-actions.md#execution-options) mode, this lets you run your mobile E2E suite **fully asynchronously** — your CI job submits the run and exits in seconds, while DeviceCloud runs the tests and reports the result straight back on the pull request.
+Install the DeviceCloud GitHub App and every test run posts a pass/fail check on the pull request that started it. It works best with the Action's [`async`](github-actions.md#execution-options) mode: your workflow submits the run and exits after a few seconds, DeviceCloud runs the tests on its own devices, and the result lands on the PR when it's ready. Nothing sits waiting on a runner, so you're not burning CI minutes while the tests execute.
 
-The payoff: your PRs get a real pass/fail gate from your mobile tests **without a CI runner sitting idle** waiting for them to finish — so you spend a fraction of the CI minutes.
-
-{% hint style="info" %}
-GitHub Checks are optional and complement the [GitHub Action](github-actions.md). If you don't install the App, the Action behaves exactly as before — blocking or `async`, your choice.
-{% endhint %}
+It's optional. Skip the App and the Action behaves exactly as it does today.
 
 ## How it works
 
-1. Your GitHub Action submits a run with `async: true` and exits immediately — the CI job is done in seconds.
-2. DeviceCloud posts an **in-progress** check on the pull request's commit.
-3. When the run completes, the check resolves to **success** or **failure**, with a summary of every flow, the failures, and a link to the full results in the console.
-4. Because it's a native GitHub check, you can **require it in branch protection** to gate merges.
+The Action submits your tests and, with `async: true`, returns straight away. DeviceCloud posts an in-progress check against the PR's commit and updates it to passed or failed once every flow has finished. The check links back to the full run in the console, and because it's an ordinary GitHub check you can require it in branch protection to keep failing builds out of your main branch.
 
-## Setup
+## Connect the App
 
-### 1. Install & connect the DeviceCloud GitHub App
+Open **Settings → Integrations** in the [console](https://console.devicecloud.dev/settings) and click **Connect GitHub**. GitHub walks you through installing the App and choosing which repositories it can see; when you come back, it's connected to your current team.
 
-In the [console](https://console.devicecloud.dev/settings), open **Settings → Integrations → Connect GitHub**. You'll be sent to GitHub to install the **DeviceCloud** App and choose which repositories it can access. When you come back, the App is connected to your current team.
+A few things worth knowing:
 
-{% hint style="info" %}
-Only team **owners and admins** can connect GitHub. If your GitHub account isn't linked to DeviceCloud yet, link it under **Settings → Account** first, then connect.
-{% endhint %}
+- Only owners and admins can connect GitHub for a team.
+- Your GitHub account needs to be linked to DeviceCloud first, under **Settings → Account**. If it isn't, the connect flow will say so.
+- If you're an admin on more than one team, you'll be asked which one to connect.
 
-If you administer more than one DeviceCloud team, you'll be asked which team to attach the installation to.
+## Run your tests
 
-### 2. Run the Action with `async`
-
-Run the [GitHub Action](github-actions.md) on your pull requests with `async: true`. The PR context (branch, commit SHA, PR number) is attached automatically, so DeviceCloud knows which pull request to post the check on.
+Run the [Action](github-actions.md) on your pull requests with `async: true`. It attaches the branch, commit, and PR number for you, which is how DeviceCloud knows where to post the check, so leave [`include-github-context`](github-actions.md#github--pr-context) on (it already is by default).
 
 ```yaml
 on:
@@ -41,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # build your app, or download a prebuilt artifact from an earlier job...
+      # build your app, or download a prebuilt artifact from an earlier job
       - uses: devicecloud-dev/device-cloud-for-maestro@v2
         with:
           api-key: ${{ secrets.DCD_API_KEY }}
@@ -49,54 +40,33 @@ jobs:
           async: true
 ```
 
-The job submits and exits in seconds, and the DeviceCloud check appears on the PR — resolving to pass/fail when the run finishes.
+The one thing to get right: the `api-key` you pass has to belong to the same team the App is connected to. If it doesn't, DeviceCloud can't match the run to your installation and nothing gets posted.
 
-{% hint style="warning" %}
-The check only posts when DeviceCloud can tie the run to a repository the App is installed on. Keep [`include-github-context`](github-actions.md#github--pr-context) at its default (`true`) so the PR and commit metadata are attached, and make sure the Action's `api-key` belongs to the same team the App is connected to.
-{% endhint %}
+## Require it before merging
 
-### 3. (Optional) Require the check to gate merges
+To make the check a merge gate, add it to a branch protection rule: your repo's **Settings → Branches → Require status checks to pass**, then pick **DeviceCloud**. GitHub only lists a check here after it's run at least once, so open a pull request before you set up the rule.
 
-To block merges on the result, add the check to your branch protection rule:
+## Re-running failures
 
-**GitHub → your repository → Settings → Branches → Add/Edit branch protection rule → Require status checks to pass before merging** — then select the **DeviceCloud** check.
+A failed check has a **Re-run failed tests** button. It re-runs only the flows that failed (free, the same as hitting retry in the console) and moves the check back to in-progress until they finish. GitHub's own re-run button on the check does the same thing.
 
-{% hint style="info" %}
-A check only appears in the branch-protection picker after it has run at least once on that repository. Open one pull request first, then add it to the rule.
-{% endhint %}
+## What the check shows
 
-## Re-running failed tests
-
-When a check fails it includes a **Re-run failed tests** button. Pressing it re-runs only the failed flows on DeviceCloud — free, exactly like the retry button in the console — and re-opens the check, which resolves again when the reruns finish. GitHub's built-in **Re-run** on the check does the same thing.
-
-## The check summary
-
-A resolved check shows:
-
-- A headline with the pass/fail count and total duration.
-- A table of every flow and its result.
-- A **Failures** section listing the reason for each failed flow.
-- A link to the full run — logs, video, and screenshots — in the DeviceCloud console.
+At the top, the pass/fail count and total runtime. Below that, a table of every flow with its result, the reason for anything that failed, and a link into the console for the logs, video, and screenshots.
 
 ## Managing the connection
 
-From **Settings → Integrations** you can see the connected GitHub account and the repositories the App can access, and **Disconnect** at any time (owner/admin only). Disconnecting uninstalls the App from GitHub and stops posting checks; you can reconnect whenever you like — the App recovers your existing installation without a fresh install.
+**Settings → Integrations** shows the connected account and the repositories the App can reach. Owners and admins can disconnect from there, which removes the App from GitHub and stops the checks. If you reconnect later, DeviceCloud picks up your existing installation instead of making you install again.
 
-## Requirements
+## When a check doesn't show up
 
-- The repository is hosted on GitHub and has the **DeviceCloud** App installed.
-- The App is connected to the DeviceCloud team that owns the `api-key` used by the Action.
-- The run carries PR/commit context — on by default via the Action's [`include-github-context`](github-actions.md#github--pr-context).
+Usually it's one of these:
 
-## Troubleshooting
-
-| Symptom | Fix |
-|---------|-----|
-| No check appears on the PR | Confirm the DeviceCloud App is **installed on the repo** and **connected to your team** (Settings → Integrations), and that the run used that team's API key. |
-| Check stays "in progress" | The run is likely still executing — check the console. The check resolves once every flow reaches a terminal state. |
-| "That GitHub account isn't linked" when connecting | Link your GitHub identity under **Settings → Account**, then connect. |
-| The check isn't listed in branch protection | It only appears after it has run once on that repository. Open a pull request first. |
+- **Nothing posts on the PR.** The App isn't installed on that repo, isn't connected to your team, or the run used a different team's API key. Check **Settings → Integrations**.
+- **The check is stuck in progress.** The run probably hasn't finished yet — find it in the console. The check only resolves once every flow reaches a final state.
+- **"That GitHub account isn't linked."** Link your GitHub identity under **Settings → Account**, then connect.
+- **The check isn't in the branch-protection list.** It has to run once on the repo before GitHub will offer it. Open a pull request first.
 
 ---
 
-**Related:** [GitHub Actions](github-actions.md) · [Async Execution](../advanced/async-execution.md)
+See also [GitHub Actions](github-actions.md) and [Async Execution](../advanced/async-execution.md).


### PR DESCRIPTION
New ci-cd/github-checks.md covering the DeviceCloud GitHub App: how the async + check flow saves CI minutes, install/connect setup, requiring the check in branch protection, re-running failed tests, the check summary, managing the connection, requirements, and troubleshooting. Added to the CI/CD nav and cross-linked from the GitHub Actions and Async Execution pages.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/devicecloud-dev/codesmith/docs/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785673608&installation_id=142781734&pr_number=91&repository=devicecloud-dev%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fdevicecloud-dev%2Fdocs%2Fpull%2F91&signature=3ada1ee207b95b42e03555d736b8cb5096f755962dfbde6ff34e256a1443809c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->