### PR TITLE
docs: document per-flow device targeting

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -25,7 +25,7 @@
 * [App Management](configuration/app-management.md)
 * [Environment Variables](configuration/environment-variables.md)
 * [Workspace Configuration](configuration/workspace-config.md)
-* [Per-flow Device Targeting](configuration/per-flow-device-targeting.md)
+* [Per-flow Devices](configuration/per-flow-devices.md)
 * [Device Locale](configuration/device-locale.md)
 * [Device Date & Time](configuration/device-datetime.md)
 * [Animations](configuration/disable-animations.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -25,6 +25,7 @@
 * [App Management](configuration/app-management.md)
 * [Environment Variables](configuration/environment-variables.md)
 * [Workspace Configuration](configuration/workspace-config.md)
+* [Per-flow Device Targeting](configuration/per-flow-device-targeting.md)
 * [Device Locale](configuration/device-locale.md)
 * [Device Date & Time](configuration/device-datetime.md)
 * [Animations](configuration/disable-animations.md)

--- a/configuration/per-flow-device-targeting.md
+++ b/configuration/per-flow-device-targeting.md
@@ -1,0 +1,104 @@
+# Per-flow Device Targeting
+
+By default every flow in an upload runs on the same device, set by the `--ios-device`,
+`--ios-version`, `--android-device` and `--android-api-level` flags on `dcd cloud`.
+
+Sometimes a single flow only matters on one device — a checkout flow you must verify on a
+tablet, an onboarding flow that has to work on your oldest supported OS. Rather than running
+a separate upload per flow, a flow can declare the device it needs directly in its YAML.
+
+A flow that declares a device runs **exactly once**, on that device. Flows that declare
+nothing inherit the upload's device, exactly as before. Your run count does not change.
+
+## Usage
+
+Set the device in the flow's `env:` frontmatter.
+
+### iOS
+
+```yaml
+# checkout-tablet.yaml
+appId: my.app
+env:
+    DEVICECLOUD_OVERRIDE_IOS_DEVICE: ipad-pro-6th-gen
+    DEVICECLOUD_OVERRIDE_IOS_VERSION: "26"
+---
+# test steps
+```
+
+### Android
+
+```yaml
+# onboarding-oldest-os.yaml
+appId: my.app
+env:
+    DEVICECLOUD_OVERRIDE_ANDROID_DEVICE: pixel-6
+    DEVICECLOUD_OVERRIDE_ANDROID_API_LEVEL: "30"
+---
+# test steps
+```
+
+Either key may be set on its own. A flow that sets only `DEVICECLOUD_OVERRIDE_IOS_DEVICE`
+keeps the upload's iOS version, and vice versa.
+
+{% hint style="info" %}
+Quote version numbers (`"26"`, `"30"`). Unquoted, YAML reads them as numbers, which still
+works, but quoting keeps the intent obvious.
+{% endhint %}
+
+See [devices-configuration.md](../getting-started/devices-configuration.md) for the valid
+device ids and the OS versions each one supports.
+
+## Precedence
+
+1. `DEVICECLOUD_OVERRIDE_*` in the flow's YAML (per test)
+2. The upload-wide `--ios-device` / `--ios-version` / `--android-device` / `--android-api-level` flags
+3. Default: iPhone 14 on iOS 17, or Pixel 7 on API level 34
+
+## Billing
+
+Each flow still runs once, so your total run count is unchanged. What can change is a flow's
+**rate**: iPad and Google Play flows are charged at our advanced rate as per our
+[pricing](../billing/test-run-billing.md). Targeting an iPad from one flow in an otherwise
+iPhone upload charges that one flow at the advanced rate, and the rest at the standard rate.
+
+## Rules
+
+**Device and OS must be a supported combination.** The device/version matrix is ragged — for
+example `iphone-15` only supports iOS 17, and `iphone-16-plus` only iOS 26. If any flow names
+an unsupported pair, the whole upload is rejected before anything runs, and the error names the
+offending flow file and the supported values for that device.
+
+**You cannot target across platforms.** One upload carries one binary, so an Android device
+override on an iOS upload is an error rather than being silently ignored — otherwise a flow you
+believed was covered would quietly run somewhere else.
+
+**Google Play must be a supported combination too.** A flow combining
+`DEVICECLOUD_OVERRIDE_GOOGLE_PLAY` with a device override is validated against the Play device
+matrix, which is currently only `pixel-7` on API level `34`. See
+[google-play-apis.md](google-play-apis.md).
+
+**Not supported on `m1` runners.** `--runner-type m1` always runs `pixel-7` on API level 34, so
+a per-flow Android device override there could never be honoured and is rejected rather than
+silently ignored.
+
+**Sequential flows do not share device state.** A `--sequential` chain whose flows target
+different devices still just orders them. Every flow boots its own clean simulator, so nothing
+carries across the chain — this is true of same-device chains today as well.
+
+## Running a whole suite across several devices
+
+Per-flow targeting picks a device for *one* flow. To run your **entire** suite against several
+devices, submit one upload per device:
+
+```bash
+for device in iphone-16-pro iphone-16-pro-max; do
+  dcd cloud --app-binary-id <id> ./flows \
+    --ios-device "$device" --ios-version 18 --async
+done
+```
+
+{% hint style="warning" %}
+`--async` matters here. Without it, each `dcd cloud` blocks on its own poll loop waiting for
+results, so the uploads run one after another instead of concurrently.
+{% endhint %}

--- a/configuration/per-flow-device-targeting.md
+++ b/configuration/per-flow-device-targeting.md
@@ -3,16 +3,16 @@
 By default every flow in an upload runs on the same device, set by the `--ios-device`,
 `--ios-version`, `--android-device` and `--android-api-level` flags on `dcd cloud`.
 
-Sometimes a single flow only matters on one device — a checkout flow you must verify on a
-tablet, an onboarding flow that has to work on your oldest supported OS. Rather than running
+Sometimes a single flow only matters on one device for example a flow you must verify on a
+tablet, or a flow that has to work on your oldest supported OS. Rather than running
 a separate upload per flow, a flow can declare the device it needs directly in its YAML.
 
-A flow that declares a device runs **exactly once**, on that device. Flows that declare
+A flow that declares a device runs as normal on that device. Flows that declare
 nothing inherit the upload's device, exactly as before. Your run count does not change.
 
 ## Usage
 
-Set the device in the flow's `env:` frontmatter.
+Set the device in the flow's `env:` block. You can find a list of supported devices and operating systems [here](../getting-started/devices-configuration.md).
 
 ### iOS
 
@@ -41,14 +41,6 @@ env:
 Either key may be set on its own. A flow that sets only `DEVICECLOUD_OVERRIDE_IOS_DEVICE`
 keeps the upload's iOS version, and vice versa.
 
-{% hint style="info" %}
-Quote version numbers (`"26"`, `"30"`). Unquoted, YAML reads them as numbers, which still
-works, but quoting keeps the intent obvious.
-{% endhint %}
-
-See [devices-configuration.md](../getting-started/devices-configuration.md) for the valid
-device ids and the OS versions each one supports.
-
 ## Precedence
 
 1. `DEVICECLOUD_OVERRIDE_*` in the flow's YAML (per test)
@@ -64,27 +56,11 @@ iPhone upload charges that one flow at the advanced rate, and the rest at the st
 
 ## Rules
 
-**Device and OS must be a supported combination.** The device/version matrix is ragged — for
-example `iphone-15` only supports iOS 17, and `iphone-16-plus` only iOS 26. If any flow names
-an unsupported pair, the whole upload is rejected before anything runs, and the error names the
-offending flow file and the supported values for that device.
+- Device and OS must be a supported combination, including Google Play if applicable.
 
-**You cannot target across platforms.** One upload carries one binary, so an Android device
-override on an iOS upload is an error rather than being silently ignored — otherwise a flow you
-believed was covered would quietly run somewhere else.
+- You cannot target across platforms in the same upload.
 
-**Google Play must be a supported combination too.** A flow combining
-`DEVICECLOUD_OVERRIDE_GOOGLE_PLAY` with a device override is validated against the Play device
-matrix, which is currently only `pixel-7` on API level `34`. See
-[google-play-apis.md](google-play-apis.md).
-
-**Not supported on `m1` runners.** `--runner-type m1` always runs `pixel-7` on API level 34, so
-a per-flow Android device override there could never be honoured and is rejected rather than
-silently ignored.
-
-**Sequential flows do not share device state.** A `--sequential` chain whose flows target
-different devices still just orders them. Every flow boots its own clean simulator, so nothing
-carries across the chain — this is true of same-device chains today as well.
+- Not supported on `m1` runners.
 
 ## Running a whole suite across several devices
 
@@ -92,13 +68,11 @@ Per-flow targeting picks a device for *one* flow. To run your **entire** suite a
 devices, submit one upload per device:
 
 ```bash
-for device in iphone-16-pro iphone-16-pro-max; do
-  dcd cloud --app-binary-id <id> ./flows \
-    --ios-device "$device" --ios-version 18 --async
-done
-```
+# iOS
+dcd cloud [...] --ios-device "<device-1>" --ios-version <version-1>
+dcd cloud [...] --ios-device "<device-2>" --ios-version <version-2>
 
-{% hint style="warning" %}
-`--async` matters here. Without it, each `dcd cloud` blocks on its own poll loop waiting for
-results, so the uploads run one after another instead of concurrently.
-{% endhint %}
+# Android
+dcd cloud [...] --android-device "<device-1>" --android-api-level <version-1>
+dcd cloud [...] --android-device "<device-2>" --android-api-level <version-2>
+```

--- a/configuration/per-flow-devices.md
+++ b/configuration/per-flow-devices.md
@@ -1,4 +1,4 @@
-# Per-flow Device Targeting
+# Per-flow Devices
 
 By default every flow in an upload runs on the same device, set by the `--ios-device`,
 `--ios-version`, `--android-device` and `--android-api-level` flags on `dcd cloud`.
@@ -60,7 +60,7 @@ iPhone upload charges that one flow at the advanced rate, and the rest at the st
 
 - You cannot target across platforms in the same upload.
 
-- Not supported on `m1` runners.
+- Currently not supported on `m1` runners due to device limitations.
 
 ## Running a whole suite across several devices
 

--- a/getting-started/devices-configuration.md
+++ b/getting-started/devices-configuration.md
@@ -84,12 +84,7 @@ dcd cloud app.zip test.yaml --ios-device ipad-pro-6th-gen
 
 ### Targeting a single flow
 
-The flags above set the device for the **whole upload**. When only one flow needs a particular
-device — a checkout flow you must verify on a tablet, say — that flow can name its own device in
-its YAML instead. See [per-flow-device-targeting.md](../configuration/per-flow-device-targeting.md).
-
-### Running a suite across several devices
-
+The flags above set the device for the **whole upload**. When only one flow needs a particular device then that flow can name its own device inits YAML instead. See [per-flow-device-targeting.md](../configuration/per-flow-device-targeting.md).
 To run your **entire** suite against more than one device, submit one upload per device:
 
 ```bash

--- a/getting-started/devices-configuration.md
+++ b/getting-started/devices-configuration.md
@@ -81,3 +81,25 @@ dcd cloud app.zip test.yaml --ios-device ipad-pro-6th-gen
 | `iphone-15`         | iPhone 15                 | 1170 x 2532 | 17                 |
 | `iphone-14`         | iPhone 14                 | 1170 x 2532 | 16 (deprecated), 17, 18 |
 | `ipad-pro-6th-gen`  | iPad Pro (6th Generation) | 2732 x 2048 | 18, 26             |
+
+### Targeting a single flow
+
+The flags above set the device for the **whole upload**. When only one flow needs a particular
+device — a checkout flow you must verify on a tablet, say — that flow can name its own device in
+its YAML instead. See [per-flow-device-targeting.md](../configuration/per-flow-device-targeting.md).
+
+### Running a suite across several devices
+
+To run your **entire** suite against more than one device, submit one upload per device:
+
+```bash
+for device in iphone-16-pro iphone-16-pro-max; do
+  dcd cloud --app-binary-id <id> ./flows \
+    --ios-device "$device" --ios-version 18 --async
+done
+```
+
+{% hint style="warning" %}
+`--async` matters here. Without it, each `dcd cloud` blocks on its own poll loop waiting for
+results, so the uploads run one after another instead of concurrently.
+{% endhint %}

--- a/getting-started/devices-configuration.md
+++ b/getting-started/devices-configuration.md
@@ -84,7 +84,7 @@ dcd cloud app.zip test.yaml --ios-device ipad-pro-6th-gen
 
 ### Targeting a single flow
 
-The flags above set the device for the **whole upload**. When only one flow needs a particular device then that flow can name its own device inits YAML instead. See [per-flow-device-targeting.md](../configuration/per-flow-device-targeting.md).
+The flags above set the device for the **whole upload**. When only one flow needs a particular device then that flow can name its own device inits YAML instead. See [per-flow-devices.md](../configuration/per-flow-devices.md).
 To run your **entire** suite against more than one device, submit one upload per device:
 
 ```bash


### PR DESCRIPTION
Adds a Configuration page for the four DEVICECLOUD_OVERRIDE_* device keys: usage, precedence, per-flow billing, and the rules users will otherwise hit as surprises — the ragged device/OS matrix, that cross-platform keys error rather than being ignored, that m1 runners reject them, and that a sequential chain spanning devices shares no state.

Also fills a gap in Devices & OS Versions, which had no example of running a whole suite across several devices. That is still one upload per device, and --async is what makes them run concurrently rather than serially.

Refs devicecloud-dev/dcd#1097

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/devicecloud-dev/codesmith/docs/pr/95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786273809&installation_id=142781734&pr_number=95&repository=devicecloud-dev%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fdevicecloud-dev%2Fdocs%2Fpull%2F95&signature=b88fa6ae0b4ec0d31d667d8e390dcc6a421e2b15e81435da133e05e3cfcfb9a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->