### PR TITLE
docs(webhooks): document per-flow tags and properties in the payload

### DIFF
--- a/notifications/webhook-notifications.md
+++ b/notifications/webhook-notifications.md
@@ -49,7 +49,12 @@ User-Agent: DeviceCloud-Webhooks/1.0
     {
       "name": "test_flow.yaml",
       "status": "PASSED",
-      "durationSeconds": 45
+      "durationSeconds": 45,
+      "tags": ["smoke"],
+      "properties": {
+        "jira_ticket": "ENG-402",
+        "deployment_env": "staging"
+      }
     }
   ],
   "metadata": {
@@ -68,9 +73,31 @@ User-Agent: DeviceCloud-Webhooks/1.0
 | `status` | Overall run outcome: `PASSED` only when every test passed, otherwise `FAILED`. Use this to gate a deploy or set a commit status. |
 | `device` | Device and runner context for the run: `name`, `osVersion`, `runnerType`, and `maestroVersion`. Individual fields are omitted when unavailable. |
 | `summary` | Aggregate counts (`totalTests`, `passed`, `failed`, and optional `cancelled`/`queued`/`pending`/`running`) plus `durationSeconds`, `wallClockDurationSeconds`, and `retryCount`. |
-| `results` | One entry per test: `name`, `status`, `durationSeconds`, and `failReason` (failures only). |
+| `results` | One entry per test: `name`, `status`, `durationSeconds`, `failReason` (failures only), plus `tags` and `properties` (see below). |
 | `metadata` | The key/value pairs you supplied via the CLI `--metadata` flag. Omitted when none were provided. |
 | `test` | Present and `true` only for test requests sent from the console. |
+
+### Tags and Custom Properties
+
+Each entry in `results` carries the `tags` and `properties` declared in that flow's YAML front matter, so you can route or filter events without a second API call:
+
+```yaml
+appId: com.example.app
+name: Login Flow
+tags:
+  - smoke
+properties:
+  jira_ticket: "ENG-402"
+  deployment_env: "staging"
+---
+- launchApp
+```
+
+`tags` and `properties` are each omitted from a result when the flow declares none.
+
+{% hint style="info" %}
+Property values are always delivered as strings — numbers and booleans are converted (`42` becomes `"42"`, `true` becomes `"true"`). Nested objects and lists are not supported and are dropped.
+{% endhint %}
 
 ### Webhook Secrets
 

--- a/notifications/webhook-notifications.md
+++ b/notifications/webhook-notifications.md
@@ -96,7 +96,11 @@ properties:
 `tags` and `properties` are each omitted from a result when the flow declares none.
 
 {% hint style="info" %}
-Property values are always delivered as strings — numbers and booleans are converted (`42` becomes `"42"`, `true` becomes `"true"`). Nested objects and lists are not supported and are dropped.
+Property values are always delivered as strings — numbers and booleans are converted (`42` becomes `"42"`, `true` becomes `"true"`).
+{% endhint %}
+
+{% hint style="warning" %}
+Property values must be scalars. Maestro rejects a flow whose `properties:` contains a nested object or a list, failing it before it runs with `Incorrect Format: <key>`.
 {% endhint %}
 
 ### Webhook Secrets


### PR DESCRIPTION
Each `results[]` entry now carries the `tags:` and `properties:` declared in that flow's YAML front matter. Document the shape, note that both are omitted when a flow declares none, and call out that property values are always delivered as strings (non-scalars are dropped).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/devicecloud-dev/codesmith/docs/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786283199&installation_id=142781734&pr_number=96&repository=devicecloud-dev%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fdevicecloud-dev%2Fdocs%2Fpull%2F96&signature=d36904b330a89973a8884a9fecb78a87bfcb8558e26afcc98594a08d659c5672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->