### PR TITLE
docs: device matrix via --ios-config/--android-config (#1105)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -26,6 +26,7 @@
 * [Environment Variables](configuration/environment-variables.md)
 * [Workspace Configuration](configuration/workspace-config.md)
 * [Per-flow Devices](configuration/per-flow-devices.md)
+* [Device Matrix](configuration/device-matrix.md)
 * [Device Locale](configuration/device-locale.md)
 * [Device Date & Time](configuration/device-datetime.md)
 * [Animations](configuration/disable-animations.md)

--- a/configuration/device-matrix.md
+++ b/configuration/device-matrix.md
@@ -1,0 +1,109 @@
+# Device Matrix
+
+By default every flow in an upload runs on one device, set by the `--ios-device`,
+`--ios-version`, `--android-device` and `--android-api-level` flags on `dcd cloud`.
+
+A **device matrix** runs your whole suite against several devices from a single `dcd cloud`
+invocation. Every flow runs once per device, all under **one upload** — one console entry, one
+pass/fail rollup, one set of tags and metadata, one binary, and results you can compare side by
+side.
+
+## Usage
+
+Pass a repeatable `--ios-device-matrix <device>:<version>` (or
+`--android-device-matrix <device>:<apiLevel>`) once per device you want. Supported devices and
+operating systems are listed [here](../getting-started/devices-configuration.md).
+
+### iOS
+
+```bash
+dcd cloud --app-binary-id <id> ./flows \
+  --ios-device-matrix iphone-16-pro:18 \
+  --ios-device-matrix iphone-16-pro:26 \
+  --ios-device-matrix iphone-16-pro-max:26
+# one upload, 3 devices x N flows
+```
+
+### Android
+
+```bash
+dcd cloud --app-binary-id <id> ./flows \
+  --android-device-matrix pixel-7:34 \
+  --android-device-matrix pixel-6:33
+```
+
+Append `:play` to run a cell against a Google Play device:
+
+```bash
+dcd cloud --app-binary-id <id> ./flows \
+  --android-device-matrix pixel-7:34 \
+  --android-device-matrix pixel-7:34:play
+```
+
+## Each flag is one device, not a combination
+
+Every `--ios-device-matrix` / `--android-device-matrix` names **exactly one device**. There is no
+cross-product: the flags are not combined with each other, or with `--ios-device` / `--ios-version`.
+
+```bash
+# runs exactly these two, and nothing else
+dcd cloud [...] --ios-device-matrix iphone-15:17 --ios-device-matrix iphone-16-plus:26
+```
+
+This is deliberate. Not every device supports every OS — iPhone 15 runs iOS 17 only, iPhone 16 Plus
+runs iOS 26 only — so combining a list of devices with a list of versions would invent pairs that
+cannot run, and reject the whole submission. Naming each device explicitly means you always get
+exactly what you asked for.
+
+## Cost
+
+A matrix runs one test per (flow x device), so a 4-device matrix over 10 flows is **40 runs**, not
+10. Before submitting, the CLI prints the number of runs and what they will cost:
+
+```
+Device matrix
+  cells       4
+  est. cost   $0.32
+  Pixel 7 - API 34   2 flows - $0.16
+  Pixel 6 - API 33   2 flows - $0.16
+```
+
+Rates are per device — iPad and Google Play cells are charged at the advanced rate, as per our
+[pricing](../billing/test-run-billing.md).
+
+## Results
+
+Each device gets its own result, grouped together in the console so you can compare a flow across
+devices at a glance.
+
+Under `--json`, every entry in `tests[]` carries a `device` object, so the same flow run on two
+devices is unambiguous:
+
+```json
+{
+  "uploadId": "...",
+  "tests": [
+    { "name": "login.yaml", "status": "PASSED", "device": { "name": "Pixel 7", "osVersion": "34" } },
+    { "name": "login.yaml", "status": "FAILED", "device": { "name": "Pixel 6", "osVersion": "33" } }
+  ]
+}
+```
+
+Without `--async` the run waits for **every** device and exits `0` only if all of them passed.
+Retrying a single failed result re-runs just that one flow on that one device — not the matrix.
+
+## Rules
+
+- Every device and OS must be a supported combination, including Google Play if applicable. An
+  unsupported one is rejected before anything runs, naming the offending cell — you never get a
+  partial submission.
+
+- **One platform per upload.** An upload runs one app binary, so `--ios-device-matrix` and
+  `--android-device-matrix` cannot be combined in the same run.
+
+- **A flow that names its own device wins.** If a flow targets a device in its YAML via
+  [per-flow devices](per-flow-devices.md), it runs once on that device and is excluded from the
+  matrix. Ten flows across four devices with one targeted flow is 37 runs, not 40.
+
+- Your DeviceCloud API must support device matrices. Against an older API the CLI refuses to
+  submit rather than quietly running everything on a single device.

--- a/configuration/device-matrix.md
+++ b/configuration/device-matrix.md
@@ -4,15 +4,11 @@ By default every flow in an upload runs on one device, set by the `--ios-device`
 `--ios-version`, `--android-device` and `--android-api-level` flags on `dcd cloud`.
 
 A **device matrix** runs your whole suite against several devices from a single `dcd cloud`
-invocation. Every flow runs once per device, all under **one upload** — one console entry, one
-pass/fail rollup, one set of tags and metadata, one binary, and results you can compare side by
-side.
+invocation. Every flow runs once per device, all under one upload with one console entry.
 
 ## Usage
 
-Pass a repeatable `--ios-device-matrix <device>:<version>` (or
-`--android-device-matrix <device>:<apiLevel>`) once per device you want. Supported devices and
-operating systems are listed [here](../getting-started/devices-configuration.md).
+Pass `--ios-device-matrix <device>:<version>` (or `--android-device-matrix <device>:<apiLevel>`) once per device you want. Supported devices and operating systems are listed [here](../getting-started/devices-configuration.md).
 
 ### iOS
 
@@ -40,8 +36,6 @@ dcd cloud --app-binary-id <id> ./flows \
   --android-device-matrix pixel-7:34:play
 ```
 
-## Each flag is one device, not a combination
-
 Every `--ios-device-matrix` / `--android-device-matrix` names **exactly one device**. There is no
 cross-product: the flags are not combined with each other, or with `--ios-device` / `--ios-version`.
 
@@ -50,15 +44,12 @@ cross-product: the flags are not combined with each other, or with `--ios-device
 dcd cloud [...] --ios-device-matrix iphone-15:17 --ios-device-matrix iphone-16-plus:26
 ```
 
-This is deliberate. Not every device supports every OS — iPhone 15 runs iOS 17 only, iPhone 16 Plus
-runs iOS 26 only — so combining a list of devices with a list of versions would invent pairs that
-cannot run, and reject the whole submission. Naming each device explicitly means you always get
+This is deliberate as not every device supports every OS. Naming each device explicitly means you always get
 exactly what you asked for.
 
 ## Cost
 
-A matrix runs one test per (flow x device), so a 4-device matrix over 10 flows is **40 runs**, not
-10. Before submitting, the CLI prints the number of runs and what they will cost:
+A matrix runs one test per (flow x device), so a 4-device matrix over 10 flows is **40 flows**, not 10. Before submitting, the CLI prints the number of flows and what they will cost:
 
 ```
 Device matrix
@@ -68,13 +59,11 @@ Device matrix
   Pixel 6 - API 33   2 flows - $0.16
 ```
 
-Rates are per device — iPad and Google Play cells are charged at the advanced rate, as per our
-[pricing](../billing/test-run-billing.md).
+Rates are per device — iPad and Google Play flows are charged at the advanced rate, as per our [pricing](../billing/test-run-billing.md).
 
 ## Results
 
-Each device gets its own result, grouped together in the console so you can compare a flow across
-devices at a glance.
+Each device gets its own result, grouped together in the console so you can compare a flow across devices at a glance.
 
 Under `--json`, every entry in `tests[]` carries a `device` object, so the same flow run on two
 devices is unambiguous:
@@ -89,21 +78,12 @@ devices is unambiguous:
 }
 ```
 
-Without `--async` the run waits for **every** device and exits `0` only if all of them passed.
-Retrying a single failed result re-runs just that one flow on that one device — not the matrix.
+Without `--async` the run waits for **every** device and exits `0` only if all of them passed. Retrying a single failed result re-runs just that one flow on that one device and not the entire matrix.
 
 ## Rules
 
-- Every device and OS must be a supported combination, including Google Play if applicable. An
-  unsupported one is rejected before anything runs, naming the offending cell — you never get a
-  partial submission.
+- Every device and OS must be a supported combination, including Google Play if applicable. An unsupported one is rejected before anything runs so you never get a partial submission.
 
-- **One platform per upload.** An upload runs one app binary, so `--ios-device-matrix` and
-  `--android-device-matrix` cannot be combined in the same run.
+- One platform per upload. An upload runs one app binary, so `--ios-device-matrix` and `--android-device-matrix` cannot be combined in the same run.
 
-- **A flow that names its own device wins.** If a flow targets a device in its YAML via
-  [per-flow devices](per-flow-devices.md), it runs once on that device and is excluded from the
-  matrix. Ten flows across four devices with one targeted flow is 37 runs, not 40.
-
-- Your DeviceCloud API must support device matrices. Against an older API the CLI refuses to
-  submit rather than quietly running everything on a single device.
+- A flow that names its own device wins. If a flow targets a device in its YAML via [per-flow devices](per-flow-devices.md), it runs once on that device and is excluded from the matrix. Ten flows across four devices with one targeted flow is 37 runs, not 40.

--- a/configuration/per-flow-devices.md
+++ b/configuration/per-flow-devices.md
@@ -65,14 +65,16 @@ iPhone upload charges that one flow at the advanced rate, and the rest at the st
 ## Running a whole suite across several devices
 
 Per-flow targeting picks a device for *one* flow. To run your **entire** suite against several
-devices, submit one upload per device:
+devices, use a [device matrix](device-matrix.md) — every flow runs once per device, under a single
+upload.
 
 ```bash
 # iOS
-dcd cloud [...] --ios-device "<device-1>" --ios-version <version-1>
-dcd cloud [...] --ios-device "<device-2>" --ios-version <version-2>
+dcd cloud [...] --ios-device-matrix iphone-16-pro:18 --ios-device-matrix iphone-16-pro-max:26
 
 # Android
-dcd cloud [...] --android-device "<device-1>" --android-api-level <version-1>
-dcd cloud [...] --android-device "<device-2>" --android-api-level <version-2>
+dcd cloud [...] --android-device-matrix pixel-7:34 --android-device-matrix pixel-6:33
 ```
+
+The two features compose: a flow that names its own device runs once on that device and is
+excluded from the matrix.

--- a/configuration/per-flow-devices.md
+++ b/configuration/per-flow-devices.md
@@ -62,19 +62,8 @@ iPhone upload charges that one flow at the advanced rate, and the rest at the st
 
 - Currently not supported on `m1` runners due to device limitations.
 
-## Running a whole suite across several devices
+## Running a suite across several devices
 
 Per-flow targeting picks a device for *one* flow. To run your **entire** suite against several
 devices, use a [device matrix](device-matrix.md) — every flow runs once per device, under a single
 upload.
-
-```bash
-# iOS
-dcd cloud [...] --ios-device-matrix iphone-16-pro:18 --ios-device-matrix iphone-16-pro-max:26
-
-# Android
-dcd cloud [...] --android-device-matrix pixel-7:34 --android-device-matrix pixel-6:33
-```
-
-The two features compose: a flow that names its own device runs once on that device and is
-excluded from the matrix.

--- a/getting-started/devices-configuration.md
+++ b/getting-started/devices-configuration.md
@@ -88,13 +88,13 @@ The flags above set the device for the **whole upload**. When only one flow need
 
 ### Running your whole suite across a device matrix
 
-To run your **entire** suite against several devices in one go, pass a repeatable `--ios-config <device>:<version>` (or `--android-config <device>:<apiLevel>`) for each device you want. Every flow runs once per config, all under **one upload** — one console entry, one pass/fail rollup, results comparable side by side.
+To run your **entire** suite against several devices in one go, pass a repeatable `--ios-device-matrix <device>:<version>` (or `--android-device-matrix <device>:<apiLevel>`) for each device you want. Every flow runs once per config, all under **one upload** — one console entry, one pass/fail rollup, results comparable side by side.
 
 ```bash
 dcd cloud --app-binary-id <id> ./flows \
-  --ios-config iphone-16-pro:18 \
-  --ios-config iphone-16-pro:26 \
-  --ios-config iphone-16-pro-max:26
+  --ios-device-matrix iphone-16-pro:18 \
+  --ios-device-matrix iphone-16-pro:26 \
+  --ios-device-matrix iphone-16-pro-max:26
 # → one upload, 3 devices × N flows
 ```
 
@@ -102,17 +102,17 @@ Android works the same way — append `:play` to target a Google Play device for
 
 ```bash
 dcd cloud --app-binary-id <id> ./flows \
-  --android-config pixel-7:34 \
-  --android-config pixel-7:34:play
+  --android-device-matrix pixel-7:34 \
+  --android-device-matrix pixel-7:34:play
 ```
 
-Each `--ios-config` / `--android-config` is **one explicit device cell** — there is no cross-product. `--ios-config iphone-15:17 --ios-config iphone-16-plus:26` runs exactly those two configs, nothing else. Every config is validated against the [compatibility tables above](#ios-devices) before anything runs, so an unsupported pair fails fast, naming it, and no partial run is submitted.
+Each `--ios-device-matrix` / `--android-device-matrix` is **one explicit device cell** — there is no cross-product. `--ios-device-matrix iphone-15:17 --ios-device-matrix iphone-16-plus:26` runs exactly those two configs, nothing else. Every config is validated against the [compatibility tables above](#ios-devices) before anything runs, so an unsupported pair fails fast, naming it, and no partial run is submitted.
 
 Before submitting, the CLI prints the number of cells and the estimated **cost** — a device matrix bills one run per (flow × config), so a 4-config matrix over 10 flows is 40 runs.
 
 A few rules:
 
-- **One platform per upload.** A matrix runs one app binary, so `--ios-config` and `--android-config` can't be combined in the same run.
+- **One platform per upload.** A matrix runs one app binary, so `--ios-device-matrix` and `--android-device-matrix` can't be combined in the same run.
 - **A flow that names its own device wins.** If a flow sets its own device via [`DEVICECLOUD_OVERRIDE_*`](../configuration/per-flow-devices.md), it runs once on that device and is excluded from the matrix.
 - **`--json` distinguishes devices.** Under `--json`, each entry in `tests[]` carries a `device` object, so the same flow run on two devices is no longer ambiguous.
 

--- a/getting-started/devices-configuration.md
+++ b/getting-started/devices-configuration.md
@@ -84,8 +84,8 @@ dcd cloud app.zip test.yaml --ios-device ipad-pro-6th-gen
 
 ### Targeting a single flow
 
-The flags above set the device for the **whole upload**. When only one flow needs a particular device then that flow can name its own device in its YAML instead. See [per-flow-devices.md](../configuration/per-flow-devices.md).
+The flags above set the device for the whole upload. When only one flow needs a particular device then that flow can name its own device in its YAML instead. See [per-flow-devices.md](../configuration/per-flow-devices.md).
 
-### Running your whole suite across several devices
+### Running your suite across several devices
 
-To run every flow against several devices from a single `dcd cloud` invocation — one upload, one pass/fail rollup, results comparable side by side — use a [device matrix](../configuration/device-matrix.md).
+To run every flow against several devices from a single `dcd cloud` invocation use a [device matrix](../configuration/device-matrix.md).

--- a/getting-started/devices-configuration.md
+++ b/getting-started/devices-configuration.md
@@ -86,36 +86,6 @@ dcd cloud app.zip test.yaml --ios-device ipad-pro-6th-gen
 
 The flags above set the device for the **whole upload**. When only one flow needs a particular device then that flow can name its own device in its YAML instead. See [per-flow-devices.md](../configuration/per-flow-devices.md).
 
-### Running your whole suite across a device matrix
+### Running your whole suite across several devices
 
-To run your **entire** suite against several devices in one go, pass a repeatable `--ios-device-matrix <device>:<version>` (or `--android-device-matrix <device>:<apiLevel>`) for each device you want. Every flow runs once per config, all under **one upload** — one console entry, one pass/fail rollup, results comparable side by side.
-
-```bash
-dcd cloud --app-binary-id <id> ./flows \
-  --ios-device-matrix iphone-16-pro:18 \
-  --ios-device-matrix iphone-16-pro:26 \
-  --ios-device-matrix iphone-16-pro-max:26
-# → one upload, 3 devices × N flows
-```
-
-Android works the same way — append `:play` to target a Google Play device for that cell:
-
-```bash
-dcd cloud --app-binary-id <id> ./flows \
-  --android-device-matrix pixel-7:34 \
-  --android-device-matrix pixel-7:34:play
-```
-
-Each `--ios-device-matrix` / `--android-device-matrix` is **one explicit device cell** — there is no cross-product. `--ios-device-matrix iphone-15:17 --ios-device-matrix iphone-16-plus:26` runs exactly those two configs, nothing else. Every config is validated against the [compatibility tables above](#ios-devices) before anything runs, so an unsupported pair fails fast, naming it, and no partial run is submitted.
-
-Before submitting, the CLI prints the number of cells and the estimated **cost** — a device matrix bills one run per (flow × config), so a 4-config matrix over 10 flows is 40 runs.
-
-A few rules:
-
-- **One platform per upload.** A matrix runs one app binary, so `--ios-device-matrix` and `--android-device-matrix` can't be combined in the same run.
-- **A flow that names its own device wins.** If a flow sets its own device via [`DEVICECLOUD_OVERRIDE_*`](../configuration/per-flow-devices.md), it runs once on that device and is excluded from the matrix.
-- **`--json` distinguishes devices.** Under `--json`, each entry in `tests[]` carries a `device` object, so the same flow run on two devices is no longer ambiguous.
-
-{% hint style="info" %}
-Prefer separate uploads (e.g. in CI, one per shard)? You can still submit one `dcd cloud` per device with `--ios-device` / `--ios-version` and `--async` — but a single matrix upload keeps the results together and comparable.
-{% endhint %}
+To run every flow against several devices from a single `dcd cloud` invocation — one upload, one pass/fail rollup, results comparable side by side — use a [device matrix](../configuration/device-matrix.md).

--- a/getting-started/devices-configuration.md
+++ b/getting-started/devices-configuration.md
@@ -84,17 +84,38 @@ dcd cloud app.zip test.yaml --ios-device ipad-pro-6th-gen
 
 ### Targeting a single flow
 
-The flags above set the device for the **whole upload**. When only one flow needs a particular device then that flow can name its own device inits YAML instead. See [per-flow-devices.md](../configuration/per-flow-devices.md).
-To run your **entire** suite against more than one device, submit one upload per device:
+The flags above set the device for the **whole upload**. When only one flow needs a particular device then that flow can name its own device in its YAML instead. See [per-flow-devices.md](../configuration/per-flow-devices.md).
+
+### Running your whole suite across a device matrix
+
+To run your **entire** suite against several devices in one go, pass a repeatable `--ios-config <device>:<version>` (or `--android-config <device>:<apiLevel>`) for each device you want. Every flow runs once per config, all under **one upload** — one console entry, one pass/fail rollup, results comparable side by side.
 
 ```bash
-for device in iphone-16-pro iphone-16-pro-max; do
-  dcd cloud --app-binary-id <id> ./flows \
-    --ios-device "$device" --ios-version 18 --async
-done
+dcd cloud --app-binary-id <id> ./flows \
+  --ios-config iphone-16-pro:18 \
+  --ios-config iphone-16-pro:26 \
+  --ios-config iphone-16-pro-max:26
+# → one upload, 3 devices × N flows
 ```
 
-{% hint style="warning" %}
-`--async` matters here. Without it, each `dcd cloud` blocks on its own poll loop waiting for
-results, so the uploads run one after another instead of concurrently.
+Android works the same way — append `:play` to target a Google Play device for that cell:
+
+```bash
+dcd cloud --app-binary-id <id> ./flows \
+  --android-config pixel-7:34 \
+  --android-config pixel-7:34:play
+```
+
+Each `--ios-config` / `--android-config` is **one explicit device cell** — there is no cross-product. `--ios-config iphone-15:17 --ios-config iphone-16-plus:26` runs exactly those two configs, nothing else. Every config is validated against the [compatibility tables above](#ios-devices) before anything runs, so an unsupported pair fails fast, naming it, and no partial run is submitted.
+
+Before submitting, the CLI prints the number of cells and the estimated **cost** — a device matrix bills one run per (flow × config), so a 4-config matrix over 10 flows is 40 runs.
+
+A few rules:
+
+- **One platform per upload.** A matrix runs one app binary, so `--ios-config` and `--android-config` can't be combined in the same run.
+- **A flow that names its own device wins.** If a flow sets its own device via [`DEVICECLOUD_OVERRIDE_*`](../configuration/per-flow-devices.md), it runs once on that device and is excluded from the matrix.
+- **`--json` distinguishes devices.** Under `--json`, each entry in `tests[]` carries a `device` object, so the same flow run on two devices is no longer ambiguous.
+
+{% hint style="info" %}
+Prefer separate uploads (e.g. in CI, one per shard)? You can still submit one `dcd cloud` per device with `--ios-device` / `--ios-version` and `--async` — but a single matrix upload keeps the results together and comparable.
 {% endhint %}


### PR DESCRIPTION
Document running a whole suite across N devices in one upload with repeatable --ios-config/--android-config, replacing the shell-loop workaround. Covers the no-cross-product rule, one-platform-per-upload, flow-override precedence, the cost preview, and the --json device field.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/devicecloud-dev/codesmith/docs/pr/97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786311385&installation_id=142781734&pr_number=97&repository=devicecloud-dev%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fdevicecloud-dev%2Fdocs%2Fpull%2F97&signature=c2dfc8d5596ded08e24bddb39922f75c95d1b4f8efb44a3a94ee6888a9596b4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->