### PR TITLE
docs: add Maestro 2.7.0 and 2.8.0

### DIFF
--- a/configuration/maestro-versions.md
+++ b/configuration/maestro-versions.md
@@ -18,12 +18,16 @@ We currently support the following versions of Maestro:
 * 2.5.1
 * 2.6.0
 * 2.6.1
+* 2.7.0
+* 2.8.0
 
 ## Version Selection
 
 You can specify a version using `--maestro-version <version>`.
 
-We additionally support the use of `--maestro-version latest` which will default to the most up-to-date version we support.
+We additionally support the use of `--maestro-version latest` which will default to the most up-to-date version we support. This currently resolves to 2.8.0.
+
+Note that Maestro 2.7.0 reorganised the per-flow debug output into a new bundle layout, with screenshots named `step-<number>-<command>.png`. If you download and process test artifacts programmatically, check your tooling against a 2.7.0 or later run before switching.
 
 ### Examples
 


### PR DESCRIPTION
Companion to devicecloud-dev/dcd#1220.

⚠️ **Do not merge until production supports both versions** — `main` publishes, and merging early advertises versions prod would reject.

Also documents that `latest` now resolves to 2.8.0, and flags 2.7.0's reorganised debug-output bundle (screenshots are now `step-<number>-<command>.png`) for anyone processing test artifacts programmatically. Default stays 2.2.0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/devicecloud-dev/codesmith/docs/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788448424&installation_model_id=425387&pr_number=99&repository=devicecloud-dev%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fdevicecloud-dev%2Fdocs%2Fpull%2F99&signature=7a6c9bae1a73353db2f8d30767d11ee5491e012a235988c8ecb9ec361e9b0800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->