### PR TITLE
docs: add Maestro 2.7.0 and 2.8.0

### DIFF
--- a/configuration/maestro-versions.md
+++ b/configuration/maestro-versions.md
@@ -18,12 +18,16 @@ We currently support the following versions of Maestro:
 * 2.5.1
 * 2.6.0
 * 2.6.1
+* 2.7.0
+* 2.8.0
 
 ## Version Selection
 
 You can specify a version using `--maestro-version <version>`.
 
-We additionally support the use of `--maestro-version latest` which will default to the most up-to-date version we support.
+We additionally support the use of `--maestro-version latest` which will default to the most up-to-date version we support. This currently resolves to 2.8.0.
+
+Note that Maestro 2.7.0 reorganised the per-flow debug output into a new bundle layout, with screenshots named `step-<number>-<command>.png`. If you download and process test artifacts programmatically, check your tooling against a 2.7.0 or later run before switching.
 
 ### Examples
 


### PR DESCRIPTION
Also notes what 'latest' now resolves to, and flags 2.7.0's artifact bundle change for anyone consuming test artifacts programmatically.

Hold this merge until production supports both versions - main publishes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/devicecloud-dev/codesmith/docs/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788448747&installation_model_id=425387&pr_number=100&repository=devicecloud-dev%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fdevicecloud-dev%2Fdocs%2Fpull%2F100&signature=319ce42e3ffe895439aed2da0349f49cf1967ebe52d044ede682859eb9e0144b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->