### PR TITLE
docs(android): document API level 37 (Android 17)

### DIFF
--- a/ci-cd/eas-workflows.md
+++ b/ci-cd/eas-workflows.md
@@ -201,7 +201,7 @@ Anything you pass on the command line after `npx @devicecloud.dev/eas-workflow@v
 | Flag | Description |
 |------|-------------|
 | `--android-device <model>` | `pixel-6`, `pixel-6-pro`, `pixel-7`, `pixel-7-pro`. |
-| `--android-api-level <n>` | `29` – `36`. Default `34`. |
+| `--android-api-level <n>` | `29` – `37`. Default `34`. |
 | `--ios-device <model>` | `iphone-14`, `iphone-15`, `iphone-16`, `iphone-16-pro`, `iphone-16-pro-max`, `ipad-pro-6th-gen`. |
 | `--ios-version <n>` | `16`, `17`, `18`, `26`. Default `17`. |
 | `--device-locale <code>` | E.g. `de_DE`. See [Device Locale](../configuration/device-locale.md). |

--- a/ci-cd/github-actions.md
+++ b/ci-cd/github-actions.md
@@ -109,7 +109,7 @@ If you build with EAS, download the build artifact in an earlier step and pass t
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `android-device` | No | — | Android device model. Options: `pixel-6`, `pixel-6-pro`, `pixel-7`, `pixel-7-pro`, `generic-tablet`. |
-| `android-api-level` | No | `34` | Android API level. Options: `29`, `30`, `31`, `32`, `33`, `34`, `35`, `36`. |
+| `android-api-level` | No | `34` | Android API level. Options: `29`, `30`, `31`, `32`, `33`, `34`, `35`, `36`, `37`. |
 | `ios-device` | No | — | iOS device model. Options: `iphone-14`, `iphone-15`,  `iphone-16`, `iphone-16-plus`, `iphone-16-pro`, `iphone-16-pro-max`, `ipad-pro-6th-gen`. |
 | `ios-version` | No | `17` | Major iOS version. Options: `16`, `17`, `18`, `26`. |
 | `device-locale` | No | — | Device locale in `ISO-639-1_ISO-3166-1` format (e.g. `de_DE`). See [Device Locale](../configuration/device-locale.md). |

--- a/getting-started/devices-configuration.md
+++ b/getting-started/devices-configuration.md
@@ -18,6 +18,7 @@ dcd cloud app.apk test.yaml --android-api-level 35
 
 | Android Version | API Level |
 | --------------- | --------- |
+| Android 17      | 37        |
 | Android 16      | 36        |
 | Android 15      | 35        |
 | Android 14      | 34        |
@@ -39,10 +40,10 @@ dcd cloud app.apk test.yaml --android-device pixel-6
 
 | id               | Name                                                                                   | Dimensions  | Valid Android API Levels       |
 | ---------------- | -------------------------------------------------------------------------------------- | ----------- | ------------------------------ |
-| `pixel-6`        | Pixel 6                                                                                | 1080 x 2400 | 29, 30, 31, 32, 33, 34, 35, 36 |
+| `pixel-6`        | Pixel 6                                                                                | 1080 x 2400 | 29, 30, 31, 32, 33, 34, 35, 36, 37 |
 | `pixel-6-pro`    | Pixel 6 Pro                                                                            | 1440 x 3120 | 33, 35                         |
-| `pixel-7`        | Pixel 7                                                                                | 1080 x 2340 | 33, 34, 35, 36                 |
-| `pixel-7-pro`    | Pixel 7 Pro                                                                            | 1440 x 3120 | 33, 34, 35, 36                 |
+| `pixel-7`        | Pixel 7                                                                                | 1080 x 2340 | 33, 34, 35, 36, 37             |
+| `pixel-7-pro`    | Pixel 7 Pro                                                                            | 1440 x 3120 | 33, 34, 35, 36, 37             |
 | `generic-tablet` | Generic Tablet (Note: starts in landscape by default, use orientation=90 for portrait) | 1440 x 3120 | 33                             |
 
 ### iOS Versions


### PR DESCRIPTION
Adds Android 17 / API 37 to the version table and to the valid levels for pixel-6, pixel-7 and pixel-7-pro, plus the CLI and GitHub Action ranges.

Do not merge ahead of the production rollout — this is the public docs site, and API 37 is dev-only until the promote workflows run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/devicecloud-dev/codesmith/docs/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->