### PR TITLE
docs: surface MCP in its own nav section, rebuild the landing page

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -8,4 +8,8 @@ redirects:
   # The MCP server docs moved out of the CLI Reference section into their own
   # top-level group. Keep the old URL working — it's what's been shared in
   # Discord MCP-setup threads.
-  cli/mcp-server: mcp/overview.md
+  #
+  # Note the source is the PUBLISHED url path, not the repo path: GitBook
+  # builds urls as <slugified SUMMARY group heading>/<filename>, so
+  # cli/mcp-server.md was served at /cli-reference/mcp-server.
+  cli-reference/mcp-server: mcp/overview.md

--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,11 @@
+root: ./
+
+structure:
+  readme: README.md
+  summary: SUMMARY.md
+
+redirects:
+  # The MCP server docs moved out of the CLI Reference section into their own
+  # top-level group. Keep the old URL working — it's what's been shared in
+  # Discord MCP-setup threads.
+  cli/mcp-server: mcp/overview.md

--- a/README.md
+++ b/README.md
@@ -10,3 +10,105 @@ Reasons to switch:
 * Google Play APIs
 * Tablets and iPads
 * Fast support response times (via Discord or Slack Connect)
+
+## Try it
+
+The CLI is intentionally designed to mimic the Maestro Cloud API, so in most cases the migration is one line:
+
+```bash
+# before
+maestro cloud --apiKey <apiKey> <appFile> <flowFile>
+
+# after
+dcd cloud <appFile> <flowFile>
+```
+
+Start with the [Quick Start](getting-started/quickstart.md) to install the CLI and run your first flow.
+
+## Quick links
+
+### Get started
+
+* [Quick Start](getting-started/quickstart.md) - install the CLI and run your first flow
+* [Authentication](getting-started/api-keys.md) - `dcd login` locally, API key in CI
+* [Flows & Workspaces](getting-started/flows-and-workspaces.md) - run a single file, a directory, or a whole workspace
+* [Devices & OS Versions](getting-started/devices-configuration.md) - every supported device, Android API level and iOS version
+
+### Run in CI
+
+* [CI/CD Integration](ci-cd/overview.md) - supported providers, and the features that matter in a pipeline
+* [GitHub Actions](ci-cd/github-actions.md) - drop-in replacement for the Maestro Cloud action
+* [GitHub Checks](ci-cd/github-checks.md) - report pass/fail straight onto the pull request
+* [Artifacts & Downloads](artifacts/artifacts.md) - pull logs, screenshots, videos and reports
+
+### Configure your runs
+
+* [Device Matrix](configuration/device-matrix.md) - run your suite across several devices in one upload
+* [Maestro Versions](configuration/maestro-versions.md) - pin a Maestro version, or track `latest`
+* [Environment Variables](configuration/environment-variables.md) - inject config and secrets into your flows
+
+### Automate with AI & code
+
+* [MCP Server](mcp/overview.md) - let Claude, Cursor and other MCP clients run your tests
+* [CLI Reference](cli/overview.md) - every `dcd` command and flag
+* [REST API](api/overview.md) - uploads, results and flows over HTTP
+
+### Pricing & plans
+
+* [Test Run Billing](billing/test-run-billing.md) - what a single test run costs
+* [Subscriptions](billing/subscriptions.md) - the Pro, Max and Enterprise plans
+* [Concurrency & Parallel Runs](getting-started/concurrency-and-parallel-runs.md) - how many of your tests run at once
+
+## FAQ
+
+### Is DeviceCloud really a drop-in replacement for Maestro Cloud?
+
+For most projects, yes. The CLI mimics the Maestro Cloud API, so you change `maestro cloud` to `dcd cloud` and drop the `--apiKey` flag. On GitHub Actions you swap a single `uses:` line — all other inputs are compatible. See [Quick Start](getting-started/quickstart.md) and [Migrating from Maestro Cloud](ci-cd/github-actions.md#migrating-from-maestro-cloud).
+
+### How much does it cost?
+
+DeviceCloud bills per test run — a single top-level flow on a single device — at $0.11 for standard iOS and $0.09 for standard Android. iPad, Google Play, tablet and non-default runner flows are charged at the advanced rate of $0.15. New accounts get $20 of free credits. See [Test Run Billing](billing/test-run-billing.md).
+
+### How many tests can I run in parallel?
+
+It depends on your plan: Pro runs up to 5 iOS and 5 Android tests at once, and Max up to 20 of each. Enterprise concurrency is arranged to fit your requirements. Once you hit your maximum, further tests queue and start automatically as capacity frees up. See [Concurrency & Parallel Runs](getting-started/concurrency-and-parallel-runs.md) and [Subscriptions](billing/subscriptions.md).
+
+### Which devices and OS versions can I run on?
+
+Android covers Pixel 6, 6 Pro, 7 and 7 Pro plus a generic tablet, on API levels 29–36, defaulting to a Pixel 7 on API 34. iOS covers the iPhone 14, 15 and 16 families and the iPad Pro (6th generation) on iOS 17, 18 and 26 — iOS 16 is deprecated and will be removed on 23 August 2026. Not every device supports every OS version, so check the availability tables in [Devices & OS Versions](getting-started/devices-configuration.md).
+
+### Which Maestro versions are supported?
+
+Ten versions from 2.0.4 to 2.8.0, selected with `--maestro-version`. Runs default to 2.2.0, and `--maestro-version latest` currently resolves to 2.8.0. We periodically remove support for older versions, so it's worth staying up to date. See [Maestro Versions](configuration/maestro-versions.md).
+
+### Do I need an API key, or can I just log in?
+
+Both work. Run `dcd login` once for local use and the CLI stores a session, so you never pass a key on a command. In CI or any headless environment, set `DEVICE_CLOUD_API_KEY` or pass `--api-key`. When more than one credential is present, precedence is the `--api-key` flag, then the environment variable, then the stored session. See [Authentication](getting-started/api-keys.md).
+
+### How do I run DeviceCloud in my CI?
+
+There are first-class integrations for GitHub Actions, Bitrise, Bitbucket Pipelines and EAS Workflows. Any other provider can call the CLI directly with `npx --yes @devicecloud.dev/dcd@latest cloud <app-file> <flows-dir>` and gate the build on the [exit code](advanced/exit-codes.md). See [CI/CD Integration](ci-cd/overview.md).
+
+### How do I get videos, logs and test reports?
+
+Pass `--download-artifacts ALL` (or `FAILED`) to a `dcd cloud` run, or fetch them after the fact with `dcd artifacts --upload-id <uuid> --download-artifacts ALL`. Everything is also downloadable from the console. Reports are available as `junit`, `html`, `html-detailed` and `allure` via `--report`. See [Artifacts & Downloads](artifacts/artifacts.md) and [Report Formats](artifacts/report-formats.md).
+
+### Is there a time limit on a test?
+
+Yes — every flow has a 10-minute execution limit, after which it is automatically cancelled. Failed tests can be retried up to twice, giving a maximum of three total runs, free of charge. See [Quick Start](getting-started/quickstart.md#limits) and [Retry Strategies](advanced/retry-strategies.md).
+
+### Can I allow-list DeviceCloud in our firewall?
+
+Yes. Test runner egress comes from a published set of IP ranges, and the same list is served from an unauthenticated endpoint — `GET https://api.devicecloud.dev/ip-addresses` — so your tooling can poll it rather than watching a docs page. See [IP Addresses](security/ip-addresses.md).
+
+### Can AI agents drive DeviceCloud?
+
+Yes. The `@devicecloud.dev/dcd` package ships `dcd-mcp`, a Model Context Protocol server that lets Claude, Cursor, VS Code and other MCP clients list devices, submit runs, check status and download artifacts. It's in beta, and the one billable tool can be hidden entirely with `--read-only`. See [MCP Server](mcp/overview.md).
+
+### How do I get support?
+
+Every account gets community and team support via [Discord](https://discord.gg/gm3mJwcNw8), and you can email [support@devicecloud.dev](mailto:support@devicecloud.dev). Target initial response times run from 4 hours (urgent) to 3 business days (low), with faster targets, priority email and dedicated Slack on the Max and Enterprise plans. Support hours are 8am–8pm UK time, Monday to Friday. See [Service Level Agreements](legal/service-level-agreements.md).
+
+{% hint style="info" %}
+Question not answered here? Ask in our [Discord](https://discord.gg/gm3mJwcNw8) or email [support@devicecloud.dev](mailto:support@devicecloud.dev) — we're happy to help.
+{% endhint %}

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -56,7 +56,6 @@
 * [List](cli/dcd-list.md)
 * [Login & Accounts](cli/dcd-login.md)
 * [Live Sessions](cli/dcd-live.md)
-* [MCP Server](cli/mcp-server.md)
 
 ## REST API
 
@@ -65,6 +64,11 @@
 * [Results](api/results.md)
 * [Flows](api/flows.md)
 * [IP Addresses](api/ip-addresses.md)
+
+## AI Agents & MCP
+
+* [MCP Server](mcp/overview.md)
+* [Tools Reference](mcp/tools.md)
 
 ## Advanced
 

--- a/advanced/retry-strategies.md
+++ b/advanced/retry-strategies.md
@@ -17,5 +17,5 @@ If a test fails, DeviceCloud will re-run the test up to the specified number of 
 - Retries count toward your concurrency limit while running
 
 {% hint style="info" %}
-If your test is still failing after 2 retries, reach out on Discord for help diagnosing the root cause.
+If your test is still failing after 2 retries, reach out on [Discord](https://discord.gg/gm3mJwcNw8) for help diagnosing the root cause.
 {% endhint %}

--- a/billing/subscriptions.md
+++ b/billing/subscriptions.md
@@ -12,7 +12,7 @@ Additional usage beyond $25 will be billed as overage and charged in your next m
 
 This plan lets you run up to 5 iOS and 5 Android tests in parallel. Read about [concurrency-and-parallel-runs.md](../getting-started/concurrency-and-parallel-runs.md "mention") to understand how this may be reduced at peak times.
 
-If you require support when using this plan, you can contact our team and community via Discord.\
+If you require support when using this plan, you can contact our team and community via [Discord](https://discord.gg/gm3mJwcNw8).\
 \
 This plan supports unlimited users and unlimited apps. Results are retained for 6 months.
 

--- a/ci-cd/any-ci.md
+++ b/ci-cd/any-ci.md
@@ -8,6 +8,6 @@ We recommend using npx so you don't need to install the npm package. In CI, auth
 npx --yes @devicecloud.dev/dcd@latest cloud sample.zip ios-flow.yaml --quiet --api-key ${{ secrets.DEV_DCD_API_KEY }}
 ```
 
-If you need advice - please ask in Discord, we'd be happy to provide pointers.
+If you need advice - please ask in [Discord](https://discord.gg/gm3mJwcNw8), we'd be happy to provide pointers.
 
 Want a specific CI integration build? Please request it in [GitHub Discussions](https://github.com/orgs/devicecloud-dev/discussions)

--- a/ci-cd/bitbucket-pipelines.md
+++ b/ci-cd/bitbucket-pipelines.md
@@ -56,7 +56,7 @@ Find your API key at [console.devicecloud.dev/settings](https://console.devicecl
 
 ## Variables
 
-The pipe variables map 1:1 to the [`dcd cloud`](dcd-cloud.md) CLI flags. The full list lives in the pipe's [README](https://bitbucket.org/devicecloud-dev/device-cloud-for-bitbucket/src/main/README.md). Required: `API_KEY`. Common ones:
+The pipe variables map 1:1 to the [`dcd cloud`](../cli/dcd-cloud.md) CLI flags. The full list lives in the pipe's [README](https://bitbucket.org/devicecloud-dev/device-cloud-for-bitbucket/src/main/README.md). Required: `API_KEY`. Common ones:
 
 | Variable | Description |
 |---|---|

--- a/cli/overview.md
+++ b/cli/overview.md
@@ -2,10 +2,10 @@
 
 The DCD CLI is the primary way to interact with DeviceCloud from your terminal or CI/CD pipeline. It is a drop-in replacement for `maestro cloud` — in most cases you can swap `maestro cloud` for `dcd cloud`.
 
-The CLI is published as `@devicecloud.dev/dcd` on npm and as a standalone binary. The same package also ships an [MCP server](mcp-server.md) so AI agents can drive DeviceCloud directly.
+The CLI is published as `@devicecloud.dev/dcd` on npm and as a standalone binary. The same package also ships an [MCP server](../mcp/overview.md) so AI agents can drive DeviceCloud directly.
 
 {% hint style="info" %}
-**New in v5:** browser-based [`dcd login`](dcd-login.md) (no more passing a key on every command), a standalone binary installer with `dcd upgrade`, interactive [`dcd live`](dcd-live.md) device sessions, and an [MCP server](mcp-server.md). Existing API keys and `dcd cloud` usage continue to work unchanged.
+**New in v5:** browser-based [`dcd login`](dcd-login.md) (no more passing a key on every command), a standalone binary installer with `dcd upgrade`, interactive [`dcd live`](dcd-live.md) device sessions, and an [MCP server](../mcp/overview.md). Existing API keys and `dcd cloud` usage continue to work unchanged.
 {% endhint %}
 
 ## Installation

--- a/getting-started/quickstart.md
+++ b/getting-started/quickstart.md
@@ -64,7 +64,7 @@ dcd cloud <appFile>.app <flowFile>
 dcd cloud <appFile>.apk <flowFile>
 ```
 
-That's it! Questions? Issues? Head to our Discord.
+That's it! Questions? Issues? Head to our [Discord](https://discord.gg/gm3mJwcNw8).
 
 ---
 

--- a/mcp/overview.md
+++ b/mcp/overview.md
@@ -31,19 +31,25 @@ Add the server to your MCP client's configuration. It runs over stdio via `npx`,
 Auth is inherited from the CLI:
 
 - Set `DEVICE_CLOUD_API_KEY` in the server's `env` (as above), **or**
-- Run [`dcd login`](dcd-login.md) once and the server will pick up the stored session.
+- Run [`dcd login`](../cli/dcd-login.md) once and the server will pick up the stored session.
+
+When both are present, the environment variable wins.
+
+Credentials are resolved lazily on the first tool call, not at startup — so your client can connect and enumerate the tools before you've supplied a key, and a bad credential surfaces as a tool error rather than a server that won't start.
 
 ## Tools
 
+The server exposes five tools. Four are read-only; `dcd_run_cloud_test` submits a run and is billable.
+
 | Tool | What it does |
 |------|--------------|
-| `dcd_list_devices` | Discover available devices, OS versions, and Maestro versions |
-| `dcd_list_runs` | List recent test runs (filter by name/date, paginated) |
-| `dcd_get_status` | Get the status and per-test results of a run |
-| `dcd_download_artifacts` | Download a run's artifacts or report to disk |
-| `dcd_run_cloud_test` | Submit a flow to run on the cloud (**billable**) |
+| [`dcd_list_devices`](tools.md#dcd-list-devices) | Discover available devices, OS versions, and Maestro versions |
+| [`dcd_list_runs`](tools.md#dcd-list-runs) | List recent test runs (filter by name/date, paginated) |
+| [`dcd_get_status`](tools.md#dcd-get-status) | Get the status and per-test results of a run |
+| [`dcd_download_artifacts`](tools.md#dcd-download-artifacts) | Download a run's artifacts or report to disk |
+| [`dcd_run_cloud_test`](tools.md#dcd-run-cloud-test) | Submit a flow to run on the cloud (**billable**) |
 
-By default `dcd_run_cloud_test` is asynchronous: it returns an `uploadId` immediately, which you poll with `dcd_get_status`. Pass `wait: true` (bounded by `waitTimeoutSeconds`) to block until the run completes, or `dryRun: true` to preview the flows without submitting.
+See [Tools Reference](tools.md) for every parameter, default, and return shape.
 
 ## Read-only mode
 
@@ -52,4 +58,16 @@ By default `dcd_run_cloud_test` is asynchronous: it returns an `uploadId` immedi
 - pass `--read-only` in `args`, or
 - set `DCD_MCP_READONLY=1` in `env`.
 
-The remaining tools are all read-only.
+The remaining tools are all read-only. A read-only server doesn't just refuse the tool — it never advertises it, so an agent can't attempt a billable run at all:
+
+```jsonc
+{
+  "mcpServers": {
+    "devicecloud": {
+      "command": "npx",
+      "args": ["-y", "@devicecloud.dev/dcd", "dcd-mcp", "--read-only"],
+      "env": { "DEVICE_CLOUD_API_KEY": "<your-api-key>" }
+    }
+  }
+}
+```

--- a/mcp/tools.md
+++ b/mcp/tools.md
@@ -1,0 +1,118 @@
+# Tools Reference
+
+Every tool the [MCP server](overview.md) exposes, with its parameters and return shape.
+
+All tools return pretty-printed JSON as their text payload. Failures come back as an error result the agent can read and react to — a failing tool never tears down the server, so an agent can recover and retry.
+
+{% hint style="warning" %}
+The MCP server is a new, beta capability. The tool surface may change.
+{% endhint %}
+
+## dcd_list_devices <a href="#dcd-list-devices" id="dcd-list-devices"></a>
+
+Discover the devices, OS versions, and Maestro versions available to your organisation. Agents should call this **before** `dcd_run_cloud_test` so they pass valid device values.
+
+Takes no parameters.
+
+Returns `{ ios, android, androidPlay, maestro }`, where each platform maps an OS version to its supported device list. See [Devices & OS Versions](../getting-started/devices-configuration.md) and [Maestro Versions](../configuration/maestro-versions.md).
+
+## dcd_list_runs <a href="#dcd-list-runs" id="dcd-list-runs"></a>
+
+List recent flow uploads for your organisation, most recent first.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Filter by upload name. Supports a `*` wildcard, e.g. `nightly-*` |
+| `from` | string | Only uploads created on or after this ISO 8601 date, e.g. `2024-01-01` |
+| `to` | string | Only uploads created on or before this ISO 8601 date |
+| `limit` | integer | Maximum uploads to return, 1–100 (default `20`) |
+| `offset` | integer | Uploads to skip, for pagination (default `0`) |
+
+Returns `{ uploads: [{ id, name, created_at, consoleUrl }], total, limit, offset }`. Use a returned `id` with `dcd_get_status` or `dcd_download_artifacts`.
+
+## dcd_get_status <a href="#dcd-get-status" id="dcd-get-status"></a>
+
+Get the status and per-test results of a single upload. This is the polling primitive: after an async `dcd_run_cloud_test`, call this until `status` leaves `PENDING` / `QUEUED` / `RUNNING`.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `uploadId` | string | UUID of the upload, as returned by `dcd_run_cloud_test` or `dcd_list_runs` |
+| `name` | string | Name of the upload to look up |
+
+Provide **exactly one** of `uploadId` or `name` — passing both, or neither, is an error.
+
+Returns `{ status, name, createdAt, tests: [{ name, status, durationSeconds, failReason }] }`.
+
+## dcd_download_artifacts <a href="#dcd-download-artifacts" id="dcd-download-artifacts"></a>
+
+Download a completed run's artifacts (the videos/logs zip) and/or a formatted report to local disk. It reads cloud state and writes local files, so it stays available in [read-only mode](overview.md#read-only-mode).
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `uploadId` | string | **Required.** UUID of the upload to download artifacts for |
+| `type` | `ALL` \| `FAILED` | Which tests to include artifacts for (default `ALL`) |
+| `artifactsPath` | string | Where to write the artifacts zip (default `./artifacts.zip`) |
+| `report` | `junit` \| `allure` \| `html` | Also download a formatted report of this type |
+| `reportPath` | string | Where to write the report (defaults by type: `report.xml` for `junit`, otherwise `report.html`) |
+
+Returns `{ uploadId, artifactsPath, reportPath, warnings }`. A **non-empty `warnings` array means a download could not be produced** — most often because the run has no results yet. An empty array means success. See [Artifacts & Downloads](../artifacts/artifacts.md) and [Report Formats](../artifacts/report-formats.md).
+
+## dcd_run_cloud_test <a href="#dcd-run-cloud-test" id="dcd-run-cloud-test"></a>
+
+Submit a Maestro flow, or a directory of flows, to run on DeviceCloud.
+
+{% hint style="warning" %}
+This tool consumes test credits. It's annotated as destructive so clients can prompt before calling it, and it's hidden entirely in [read-only mode](overview.md#read-only-mode).
+{% endhint %}
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `flowFile` | string | **Required.** Path to a Maestro `.yaml`/`.yml` flow, or a directory of flows |
+| `appFile` | string | Path to a local app binary — `.apk`, `.app`, or `.zip`. Mutually exclusive with `appBinaryId` |
+| `appBinaryId` | string | ID of a previously uploaded binary. Mutually exclusive with `appFile` |
+| `iosVersion` | string | iOS version, e.g. `17` |
+| `iosDevice` | string | iOS device, e.g. `iphone-14` |
+| `androidApiLevel` | string | Android API level, e.g. `34` |
+| `androidDevice` | string | Android device, e.g. `pixel-7` |
+| `googlePlay` | boolean | Use a [Google Play-enabled](../configuration/google-play-apis.md) Android image |
+| `name` | string | A name for this run |
+| `env` | string[] | [Environment variables](../configuration/environment-variables.md) as `KEY=VALUE` strings |
+| `includeTags` | string[] | Only run flows with these tags |
+| `excludeTags` | string[] | Skip flows with these tags |
+| `excludeFlows` | string[] | Flow paths/patterns to exclude |
+| `maestroVersion` | string | Pin a specific [Maestro version](../configuration/maestro-versions.md) |
+| `retry` | integer | Auto-[retry](../advanced/retry-strategies.md) failed tests, 0–2 |
+| `runnerType` | `default` \| `m4` \| `m1` \| `gpu1` \| `cpu1` | [Runner type](../configuration/runner-type.md) (default `default`) |
+| `configFile` | string | Path to a [workspace config](../configuration/workspace-config.md) |
+| `ignoreShaCheck` | boolean | Force re-upload of the binary even if an identical one already exists |
+| `dryRun` | boolean | Preview which flows would run, without submitting |
+| `wait` | boolean | Block until the run completes instead of returning immediately (default `false`) |
+| `waitTimeoutSeconds` | integer | Max seconds to wait when `wait` is true, 30–3600 (default `600`) |
+
+You must provide either `appFile` or `appBinaryId` — not both, and not neither. Use [`dcd upload`](../cli/dcd-upload.md) or a previous run to get a reusable `appBinaryId`.
+
+### Async by default
+
+By default the tool returns as soon as the run is submitted:
+
+```json
+{ "uploadId": "...", "consoleUrl": "...", "status": "PENDING", "tests": [ ... ] }
+```
+
+Poll `dcd_get_status` with that `uploadId` until the status is terminal. This is the recommended shape for agents — it keeps the tool call short and avoids a long-blocking request.
+
+Set `wait: true` to block instead. The tool polls every 10 seconds up to `waitTimeoutSeconds`, then returns with `timedOut: true` if the run hasn't finished. **The run continues in the cloud regardless** — a timeout is not a cancellation, and you can resume by polling `dcd_get_status` with the returned `uploadId`.
+
+### Previewing a run
+
+`dryRun: true` resolves the flows and returns them without submitting anything or spending credits:
+
+```json
+{
+  "dryRun": true,
+  "flows": [{ "file": "...", "flowName": "...", "tags": [ ... ] }],
+  "sequentialFlowCount": 0
+}
+```
+
+This is a cheap way for an agent to confirm it's about to run the flows you expect before it calls the billable path for real.


### PR DESCRIPTION
The MCP server docs were the last entry in the CLI Reference group, under nine `dcd <command>` pages, with the only inbound links being two lines in cli/overview.md — nobody was finding them. The landing page was 12 lines with zero links to anywhere.

MCP:
- Move cli/mcp-server.md to its own top-level "AI Agents & MCP" group, split into mcp/overview.md (setup, auth, read-only mode) and mcp/tools.md (per-tool parameter reference).
- Tool parameters, defaults, bounds and return shapes are taken from the zod schemas in dcd-cli/src/mcp/tools/*.ts, so the reference matches the implementation rather than restating the old summary table.
- Add .gitbook.yaml redirecting cli/mcp-server to the new location — that URL has been shared in Discord MCP-setup threads.

Landing page:
- Add a before/after `maestro cloud` -> `dcd cloud` snippet, grouped quick links (5 groups, 17 links) and a 12-question FAQ. Every FAQ answer is sourced from an existing page and links to it.
- The existing "Reasons to switch" pitch is left byte-identical.

Also:
- Link the Discord invite at all five places that said "our Discord" without a URL.
- Fix a pre-existing broken link in ci-cd/bitbucket-pipelines.md (dcd-cloud.md -> ../cli/dcd-cloud.md).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/devicecloud-dev/codesmith/docs/pr/102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->